### PR TITLE
added catching exceptions when starting SMTPSendMail and redirecting …

### DIFF
--- a/vertx-mail-client/src/main/java/io/vertx/ext/mail/impl/SMTPSendMail.java
+++ b/vertx-mail-client/src/main/java/io/vertx/ext/mail/impl/SMTPSendMail.java
@@ -36,8 +36,12 @@ class SMTPSendMail {
   }
 
   void start() {
-    if (checkSize()) {
-      mailFromCmd();
+    try{
+      if (checkSize()) {
+        mailFromCmd();
+      }
+    }catch(Exception e){
+      handleError(e);
     }
   }
 

--- a/vertx-mail-client/src/main/java/io/vertx/ext/mail/impl/SMTPSendMail.java
+++ b/vertx-mail-client/src/main/java/io/vertx/ext/mail/impl/SMTPSendMail.java
@@ -36,11 +36,11 @@ class SMTPSendMail {
   }
 
   void start() {
-    try{
+    try {
       if (checkSize()) {
         mailFromCmd();
       }
-    }catch(Exception e){
+    } catch (Exception e) {
       handleError(e);
     }
   }


### PR DESCRIPTION
…to resultHandler. allows to handle i.e. mail parsing erors by users properly

the origin of this commit is that I needed to return error status from vert.x web REST service when malformed email address was provided. without redirecting exception to resultHandler the exception gets swallowed somewhere in vert.x internals