### PR TITLE
fix issue #46: ehloCmd method is not run when Mail Server reply "ESMTP" is not all uppercase characters

### DIFF
--- a/vertx-mail-client/src/main/asciidoc/groovy/index.adoc
+++ b/vertx-mail-client/src/main/asciidoc/groovy/index.adoc
@@ -1,9 +1,7 @@
 = Vert.x Mail client (SMTP client implementation)
 
 Vert.x client for sending SMTP emails via a local mail server
-(e.g.
-
-postfix) or by external mail server (e.g. googlemail or aol).
+(e.g. postfix) or by external mail server (e.g. googlemail or aol).
 
 The client supports a few additional auth methods like DIGEST-MD5 and has full
 support for TLS and SSL and is completely asynchronous. The client supports
@@ -18,7 +16,7 @@ To use this project, add the following dependency to the _dependencies_ section 
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-mail-client</artifactId>
-  <version>3.1.0</version>
+  <version>3.2.0-SNAPSHOT</version>
 </dependency>
 ----
 
@@ -26,7 +24,7 @@ To use this project, add the following dependency to the _dependencies_ section 
 
 [source,groovy,subs="+attributes"]
 ----
-compile io.vertx:vertx-mail-client:3.1.0
+compile io.vertx:vertx-mail-client:3.2.0-SNAPSHOT
 ----
 
 == Creating a client

--- a/vertx-mail-client/src/main/asciidoc/java/index.adoc
+++ b/vertx-mail-client/src/main/asciidoc/java/index.adoc
@@ -1,9 +1,7 @@
 = Vert.x Mail client (SMTP client implementation)
 
 Vert.x client for sending SMTP emails via a local mail server
-(e.g.
-
-postfix) or by external mail server (e.g. googlemail or aol).
+(e.g. postfix) or by external mail server (e.g. googlemail or aol).
 
 The client supports a few additional auth methods like DIGEST-MD5 and has full
 support for TLS and SSL and is completely asynchronous. The client supports
@@ -18,7 +16,7 @@ To use this project, add the following dependency to the _dependencies_ section 
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-mail-client</artifactId>
-  <version>3.1.0</version>
+  <version>3.2.0-SNAPSHOT</version>
 </dependency>
 ----
 
@@ -26,7 +24,7 @@ To use this project, add the following dependency to the _dependencies_ section 
 
 [source,groovy,subs="+attributes"]
 ----
-compile io.vertx:vertx-mail-client:3.1.0
+compile io.vertx:vertx-mail-client:3.2.0-SNAPSHOT
 ----
 
 == Creating a client

--- a/vertx-mail-client/src/main/asciidoc/js/index.adoc
+++ b/vertx-mail-client/src/main/asciidoc/js/index.adoc
@@ -1,9 +1,7 @@
 = Vert.x Mail client (SMTP client implementation)
 
 Vert.x client for sending SMTP emails via a local mail server
-(e.g.
-
-postfix) or by external mail server (e.g. googlemail or aol).
+(e.g. postfix) or by external mail server (e.g. googlemail or aol).
 
 The client supports a few additional auth methods like DIGEST-MD5 and has full
 support for TLS and SSL and is completely asynchronous. The client supports
@@ -18,7 +16,7 @@ To use this project, add the following dependency to the _dependencies_ section 
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-mail-client</artifactId>
-  <version>3.1.0</version>
+  <version>3.2.0-SNAPSHOT</version>
 </dependency>
 ----
 
@@ -26,7 +24,7 @@ To use this project, add the following dependency to the _dependencies_ section 
 
 [source,groovy,subs="+attributes"]
 ----
-compile io.vertx:vertx-mail-client:3.1.0
+compile io.vertx:vertx-mail-client:3.2.0-SNAPSHOT
 ----
 
 == Creating a client

--- a/vertx-mail-client/src/main/asciidoc/ruby/index.adoc
+++ b/vertx-mail-client/src/main/asciidoc/ruby/index.adoc
@@ -1,9 +1,7 @@
 = Vert.x Mail client (SMTP client implementation)
 
 Vert.x client for sending SMTP emails via a local mail server
-(e.g.
-
-postfix) or by external mail server (e.g. googlemail or aol).
+(e.g. postfix) or by external mail server (e.g. googlemail or aol).
 
 The client supports a few additional auth methods like DIGEST-MD5 and has full
 support for TLS and SSL and is completely asynchronous. The client supports
@@ -18,7 +16,7 @@ To use this project, add the following dependency to the _dependencies_ section 
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-mail-client</artifactId>
-  <version>3.1.0</version>
+  <version>3.2.0-SNAPSHOT</version>
 </dependency>
 ----
 
@@ -26,7 +24,7 @@ To use this project, add the following dependency to the _dependencies_ section 
 
 [source,groovy,subs="+attributes"]
 ----
-compile io.vertx:vertx-mail-client:3.1.0
+compile io.vertx:vertx-mail-client:3.2.0-SNAPSHOT
 ----
 
 == Creating a client

--- a/vertx-mail-client/src/main/java/io/vertx/ext/mail/impl/SMTPInitialDialogue.java
+++ b/vertx-mail-client/src/main/java/io/vertx/ext/mail/impl/SMTPInitialDialogue.java
@@ -54,7 +54,7 @@ class SMTPInitialDialogue {
   public void start(final String message) {
     log.debug("server greeting: " + message);
     if (StatusCode.isStatusOk(message)) {
-      if (isEsmtpSupported(message)) {
+      if (Utils.isEsmtpSupported(message)) {
         ehloCmd();
       } else {
         heloCmd();
@@ -62,12 +62,6 @@ class SMTPInitialDialogue {
     } else {
       handleError("got error response " + message);
     }
-  }
-
-  private boolean isEsmtpSupported(String message) {
-    // note that message in this case is the initial reply from the server
-    // e.g. 220 example.com ESMTP Postfix
-    return message.contains("ESMTP");
   }
 
   private void ehloCmd() {

--- a/vertx-mail-client/src/main/java/io/vertx/ext/mail/impl/Utils.java
+++ b/vertx-mail-client/src/main/java/io/vertx/ext/mail/impl/Utils.java
@@ -14,9 +14,6 @@
  *  You may elect to redistribute this code under either of these licenses.
  */
 
-/**
- *
- */
 package io.vertx.ext.mail.impl;
 
 import java.util.ArrayList;
@@ -36,7 +33,7 @@ public final class Utils {
   private static final Logger log = LoggerFactory.getLogger(Utils.class);
 
   /**
-   *
+   * utility class only
    */
   private Utils() {
   }
@@ -74,11 +71,22 @@ public final class Utils {
     return lines;
   }
 
+  /**
+   * check if the welcome line of the SMTP server advertises ESMTP support
+   *
+   * this is mostly a hack to avoid trying EHLO command on servers that do not support it (e.g. a server behind a
+   * firewall with policy enforcement that overwrites all unknown text with ***).
+   *
+   * Some servers use "Esmtp" so we do a case-insensitive check. The Locale.ENGLISH parameter is required to avoid
+   * issues with locale settings that change ASCII chars (and to keep pmd happy)
+   *
+   * @param message
+   *          the initial reply from the server (e.g. "220 example.com ESMTP Postfix")
+   * @return true if ESMTP is (probably) supported
+   */
   static boolean isEsmtpSupported(String message) {
-    // note that message in this case is the initial reply from the server
-    // e.g. 220 example.com ESMTP Postfix
     final boolean esmtpSupported = message.toUpperCase(Locale.ENGLISH).contains("ESMTP");
-    log.debug("isEsmtpSupported:"+esmtpSupported);
+    log.debug("isEsmtpSupported:" + esmtpSupported);
     return esmtpSupported;
   }
 

--- a/vertx-mail-client/src/main/java/io/vertx/ext/mail/impl/Utils.java
+++ b/vertx-mail-client/src/main/java/io/vertx/ext/mail/impl/Utils.java
@@ -22,12 +22,18 @@ package io.vertx.ext.mail.impl;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
+
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
 
 /**
  * @author <a href="http://oss.lehmann.cx/">Alexander Lehmann</a>
  */
 public final class Utils {
+
+  private static final Logger log = LoggerFactory.getLogger(Utils.class);
 
   /**
    *
@@ -66,6 +72,14 @@ public final class Utils {
     }
     lines.add(message.substring(index));
     return lines;
+  }
+
+  static boolean isEsmtpSupported(String message) {
+    // note that message in this case is the initial reply from the server
+    // e.g. 220 example.com ESMTP Postfix
+    final boolean esmtpSupported = message.toUpperCase(Locale.ENGLISH).contains("ESMTP");
+    log.debug("isEsmtpSupported:"+esmtpSupported);
+    return esmtpSupported;
   }
 
 }

--- a/vertx-mail-client/src/main/resources/vertx-mail-js/mail_client.js
+++ b/vertx-mail-client/src/main/resources/vertx-mail-js/mail_client.js
@@ -47,7 +47,7 @@ var MailClient = function(j_val) {
    */
   this.sendMail = function(email, resultHandler) {
     var __args = arguments;
-    if (__args.length === 2 && typeof __args[0] === 'object' && typeof __args[1] === 'function') {
+    if (__args.length === 2 && (typeof __args[0] === 'object' && __args[0] != null) && typeof __args[1] === 'function') {
       j_mailClient["sendMail(io.vertx.ext.mail.MailMessage,io.vertx.core.Handler)"](email != null ? new MailMessage(new JsonObject(JSON.stringify(email))) : null, function(ar) {
       if (ar.succeeded()) {
         resultHandler(utils.convReturnDataObject(ar.result()), null);
@@ -88,7 +88,7 @@ var MailClient = function(j_val) {
  */
 MailClient.createNonShared = function(vertx, config) {
   var __args = arguments;
-  if (__args.length === 2 && typeof __args[0] === 'object' && __args[0]._jdel && typeof __args[1] === 'object') {
+  if (__args.length === 2 && typeof __args[0] === 'object' && __args[0]._jdel && (typeof __args[1] === 'object' && __args[1] != null)) {
     return utils.convReturnVertxGen(JMailClient["createNonShared(io.vertx.core.Vertx,io.vertx.ext.mail.MailConfig)"](vertx._jdel, config != null ? new MailConfig(new JsonObject(JSON.stringify(config))) : null), MailClient);
   } else throw new TypeError('function invoked with invalid arguments');
 };
@@ -105,9 +105,9 @@ MailClient.createNonShared = function(vertx, config) {
  */
 MailClient.createShared = function() {
   var __args = arguments;
-  if (__args.length === 2 && typeof __args[0] === 'object' && __args[0]._jdel && typeof __args[1] === 'object') {
+  if (__args.length === 2 && typeof __args[0] === 'object' && __args[0]._jdel && (typeof __args[1] === 'object' && __args[1] != null)) {
     return utils.convReturnVertxGen(JMailClient["createShared(io.vertx.core.Vertx,io.vertx.ext.mail.MailConfig)"](__args[0]._jdel, __args[1] != null ? new MailConfig(new JsonObject(JSON.stringify(__args[1]))) : null), MailClient);
-  }else if (__args.length === 3 && typeof __args[0] === 'object' && __args[0]._jdel && typeof __args[1] === 'object' && typeof __args[2] === 'string') {
+  }else if (__args.length === 3 && typeof __args[0] === 'object' && __args[0]._jdel && (typeof __args[1] === 'object' && __args[1] != null) && typeof __args[2] === 'string') {
     return utils.convReturnVertxGen(JMailClient["createShared(io.vertx.core.Vertx,io.vertx.ext.mail.MailConfig,java.lang.String)"](__args[0]._jdel, __args[1] != null ? new MailConfig(new JsonObject(JSON.stringify(__args[1]))) : null, __args[2]), MailClient);
   } else throw new TypeError('function invoked with invalid arguments');
 };

--- a/vertx-mail-client/src/test/java/io/vertx/ext/mail/HeloTest.java
+++ b/vertx-mail-client/src/test/java/io/vertx/ext/mail/HeloTest.java
@@ -24,7 +24,7 @@ import org.junit.runner.RunWith;
 
 /**
  * Test a server that doesn't support EHLO and a few errors in the server greeting
- * 
+ *
  * @author <a href="http://oss.lehmann.cx/">Alexander Lehmann</a>
  */
 @RunWith(VertxUnitRunner.class)
@@ -190,5 +190,34 @@ public class HeloTest extends SMTPTestDummy {
 
     testException();
   }
+
+  /*
+   * test that we try to use EHLO when the server sends esmtp not all uppercase
+   * (https://github.com/vert-x3/vertx-mail-client/issues/46)
+   *
+   * the check for "ESMTP" is mostly a hack to avoid sending EHLO to a server that doesn't support it, which is not very
+   * likely anymore, unless you have a firewall that blocks ESMTP commands. In this case the complete server helo
+   * message is probably blocked anyway.
+   */
+  @Test
+  public void esmtpCheckTest(TestContext testContext) {
+    this.testContext=testContext;
+    smtpServer.setDialogue("220 example.com Esmtp",
+      "EHLO",
+      "250 example.com",
+      "MAIL FROM",
+      "250 2.1.0 Ok",
+      "RCPT TO",
+      "250 2.1.5 Ok",
+      "DATA",
+      "354 End data with <CR><LF>.<CR><LF>",
+      "250 2.0.0 Ok: queued as ABCDDEF0123456789",
+      "QUIT",
+      "221 2.0.0 Bye");
+    smtpServer.setCloseImmediately(false);
+
+    testSuccess();
+  }
+
 
 }

--- a/vertx-mail-client/src/test/java/io/vertx/ext/mail/MailFromSizeTest.java
+++ b/vertx-mail-client/src/test/java/io/vertx/ext/mail/MailFromSizeTest.java
@@ -19,7 +19,6 @@ package io.vertx.ext.mail;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 

--- a/vertx-mail-client/src/test/java/io/vertx/ext/mail/impl/UtilsTest.java
+++ b/vertx-mail-client/src/test/java/io/vertx/ext/mail/impl/UtilsTest.java
@@ -13,6 +13,7 @@
  *
  *  You may elect to redistribute this code under either of these licenses.
  */
+
 package io.vertx.ext.mail.impl;
 
 import org.junit.Test;
@@ -27,7 +28,8 @@ import static org.junit.Assert.assertFalse;
 public class UtilsTest {
 
   /**
-   * Test method for {@link io.vertx.ext.mail.impl.SMTPInitialDialogue#isEsmtpSupported(java.lang.String)}.
+   * Test method for {@link io.vertx.ext.mail.impl.SMTPInitialDialogue#isEsmtpSupported(java.lang.String)}. check if we
+   * can detect ESMTP support with upper/lower case chars and not if the string contains only SMTP
    */
   @Test
   public void testIsEsmtpSupported() {

--- a/vertx-mail-client/src/test/java/io/vertx/ext/mail/impl/UtilsTest.java
+++ b/vertx-mail-client/src/test/java/io/vertx/ext/mail/impl/UtilsTest.java
@@ -1,0 +1,40 @@
+/*
+ *  Copyright (c) 2011-2015 The original author or authors
+ *
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  and Apache License v2.0 which accompanies this distribution.
+ *
+ *       The Eclipse Public License is available at
+ *       http://www.eclipse.org/legal/epl-v10.html
+ *
+ *       The Apache License v2.0 is available at
+ *       http://www.opensource.org/licenses/apache2.0.php
+ *
+ *  You may elect to redistribute this code under either of these licenses.
+ */
+package io.vertx.ext.mail.impl;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+
+/**
+ * @author <a href="http://oss.lehmann.cx/">Alexander Lehmann</a>
+ *
+ */
+public class UtilsTest {
+
+  /**
+   * Test method for {@link io.vertx.ext.mail.impl.SMTPInitialDialogue#isEsmtpSupported(java.lang.String)}.
+   */
+  @Test
+  public void testIsEsmtpSupported() {
+    assertTrue(Utils.isEsmtpSupported("220 example.com ESMTP server"));
+    assertTrue(Utils.isEsmtpSupported("220 example.com Esmtp server"));
+    assertTrue(Utils.isEsmtpSupported("220 example.com esmtp server"));
+    assertFalse(Utils.isEsmtpSupported("220 example.com SMTP server"));
+  }
+
+}

--- a/vertx-mail-service/src/main/asciidoc/groovy/index.adoc
+++ b/vertx-mail-service/src/main/asciidoc/groovy/index.adoc
@@ -17,7 +17,7 @@ To use this project, add the following dependency to the _dependencies_ section 
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-mail-service</artifactId>
-  <version>3.1.0</version>
+  <version>3.2.0-SNAPSHOT</version>
 </dependency>
 ----
 
@@ -25,7 +25,7 @@ To use this project, add the following dependency to the _dependencies_ section 
 
 [source,groovy,subs="+attributes"]
 ----
-compile io.vertx:vertx-mail-service:3.1.0
+compile io.vertx:vertx-mail-service:3.2.0-SNAPSHOT
 ----
 
 === Service client

--- a/vertx-mail-service/src/main/asciidoc/java/index.adoc
+++ b/vertx-mail-service/src/main/asciidoc/java/index.adoc
@@ -17,7 +17,7 @@ To use this project, add the following dependency to the _dependencies_ section 
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-mail-service</artifactId>
-  <version>3.1.0</version>
+  <version>3.2.0-SNAPSHOT</version>
 </dependency>
 ----
 
@@ -25,7 +25,7 @@ To use this project, add the following dependency to the _dependencies_ section 
 
 [source,groovy,subs="+attributes"]
 ----
-compile io.vertx:vertx-mail-service:3.1.0
+compile io.vertx:vertx-mail-service:3.2.0-SNAPSHOT
 ----
 
 === Service client

--- a/vertx-mail-service/src/main/asciidoc/js/index.adoc
+++ b/vertx-mail-service/src/main/asciidoc/js/index.adoc
@@ -17,7 +17,7 @@ To use this project, add the following dependency to the _dependencies_ section 
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-mail-service</artifactId>
-  <version>3.1.0</version>
+  <version>3.2.0-SNAPSHOT</version>
 </dependency>
 ----
 
@@ -25,7 +25,7 @@ To use this project, add the following dependency to the _dependencies_ section 
 
 [source,groovy,subs="+attributes"]
 ----
-compile io.vertx:vertx-mail-service:3.1.0
+compile io.vertx:vertx-mail-service:3.2.0-SNAPSHOT
 ----
 
 === Service client

--- a/vertx-mail-service/src/main/asciidoc/ruby/index.adoc
+++ b/vertx-mail-service/src/main/asciidoc/ruby/index.adoc
@@ -17,7 +17,7 @@ To use this project, add the following dependency to the _dependencies_ section 
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-mail-service</artifactId>
-  <version>3.1.0</version>
+  <version>3.2.0-SNAPSHOT</version>
 </dependency>
 ----
 
@@ -25,7 +25,7 @@ To use this project, add the following dependency to the _dependencies_ section 
 
 [source,groovy,subs="+attributes"]
 ----
-compile io.vertx:vertx-mail-service:3.1.0
+compile io.vertx:vertx-mail-service:3.2.0-SNAPSHOT
 ----
 
 === Service client

--- a/vertx-mail-service/src/main/resources/vertx-mail-js/mail_client.js
+++ b/vertx-mail-service/src/main/resources/vertx-mail-js/mail_client.js
@@ -1,29 +1,29 @@
 /*
- *  Copyright (c) 2011-2015 The original author or authors
+ * Copyright 2014 Red Hat, Inc.
  *
- *  All rights reserved. This program and the accompanying materials
- *  are made available under the terms of the Eclipse Public License v1.0
- *  and Apache License v2.0 which accompanies this distribution.
+ * Red Hat licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
  *
- *       The Eclipse Public License is available at
- *       http://www.eclipse.org/legal/epl-v10.html
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *       The Apache License v2.0 is available at
- *       http://www.opensource.org/licenses/apache2.0.php
- *
- *  You may elect to redistribute this code under either of these licenses.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  */
 
 /** @module vertx-mail-js/mail_client */
 var utils = require('vertx-js/util/utils');
+var Vertx = require('vertx-js/vertx');
 
 var io = Packages.io;
 var JsonObject = io.vertx.core.json.JsonObject;
 var JMailClient = io.vertx.ext.mail.MailClient;
 var MailConfig = io.vertx.ext.mail.MailConfig;
-var MailConfig = io.vertx.ext.mail.MailConfig;
-var MailConfig = io.vertx.ext.mail.MailConfig;
 var MailMessage = io.vertx.ext.mail.MailMessage;
+var MailResult = io.vertx.ext.mail.MailResult;
 
 /**
  @class
@@ -42,16 +42,16 @@ var MailClient = function(j_val) {
    */
   this.sendMail = function(arg0, arg1) {
     var __args = arguments;
-    if (__args.length === 2 && typeof __args[0] === 'object' && typeof __args[1] === 'function') {
+    if (__args.length === 2 && (typeof __args[0] === 'object' && __args[0] != null) && typeof __args[1] === 'function') {
       j_mailClient["sendMail(io.vertx.ext.mail.MailMessage,io.vertx.core.Handler)"](arg0 != null ? new MailMessage(new JsonObject(JSON.stringify(arg0))) : null, function(ar) {
       if (ar.succeeded()) {
-        arg1(utils.convReturnJson(ar.result().toJson()), null);
+        arg1(utils.convReturnDataObject(ar.result()), null);
       } else {
         arg1(null, ar.cause());
       }
     });
       return that;
-    } else utils.invalidArgs();
+    } else throw new TypeError('function invoked with invalid arguments');
   };
 
   /**
@@ -63,7 +63,7 @@ var MailClient = function(j_val) {
     var __args = arguments;
     if (__args.length === 0) {
       j_mailClient["close()"]();
-    } else utils.invalidArgs();
+    } else throw new TypeError('function invoked with invalid arguments');
   };
 
   // A reference to the underlying Java delegate
@@ -81,9 +81,9 @@ var MailClient = function(j_val) {
  */
 MailClient.createNonShared = function(vertx, config) {
   var __args = arguments;
-  if (__args.length === 2 && typeof __args[0] === 'object' && __args[0]._jdel && typeof __args[1] === 'object') {
+  if (__args.length === 2 && typeof __args[0] === 'object' && __args[0]._jdel && (typeof __args[1] === 'object' && __args[1] != null)) {
     return utils.convReturnVertxGen(JMailClient["createNonShared(io.vertx.core.Vertx,io.vertx.ext.mail.MailConfig)"](vertx._jdel, config != null ? new MailConfig(new JsonObject(JSON.stringify(config))) : null), MailClient);
-  } else utils.invalidArgs();
+  } else throw new TypeError('function invoked with invalid arguments');
 };
 
 /**
@@ -96,11 +96,11 @@ MailClient.createNonShared = function(vertx, config) {
  */
 MailClient.createShared = function() {
   var __args = arguments;
-  if (__args.length === 2 && typeof __args[0] === 'object' && __args[0]._jdel && typeof __args[1] === 'object') {
+  if (__args.length === 2 && typeof __args[0] === 'object' && __args[0]._jdel && (typeof __args[1] === 'object' && __args[1] != null)) {
     return utils.convReturnVertxGen(JMailClient["createShared(io.vertx.core.Vertx,io.vertx.ext.mail.MailConfig)"](__args[0]._jdel, __args[1] != null ? new MailConfig(new JsonObject(JSON.stringify(__args[1]))) : null), MailClient);
-  }else if (__args.length === 3 && typeof __args[0] === 'object' && __args[0]._jdel && typeof __args[1] === 'object' && typeof __args[2] === 'string') {
+  }else if (__args.length === 3 && typeof __args[0] === 'object' && __args[0]._jdel && (typeof __args[1] === 'object' && __args[1] != null) && typeof __args[2] === 'string') {
     return utils.convReturnVertxGen(JMailClient["createShared(io.vertx.core.Vertx,io.vertx.ext.mail.MailConfig,java.lang.String)"](__args[0]._jdel, __args[1] != null ? new MailConfig(new JsonObject(JSON.stringify(__args[1]))) : null, __args[2]), MailClient);
-  } else utils.invalidArgs();
+  } else throw new TypeError('function invoked with invalid arguments');
 };
 
 // We export the Constructor function

--- a/vertx-mail-service/src/main/resources/vertx-mail-js/mail_service-proxy.js
+++ b/vertx-mail-service/src/main/resources/vertx-mail-js/mail_service-proxy.js
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2014 Red Hat, Inc.
+ *
+ * Red Hat licenses this file to you under the Apache License, version 2.0
+ * (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at:
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+/** @module vertx-mail-js/mail_service */
+!function (factory) {
+  if (typeof require === 'function' && typeof module !== 'undefined') {
+    factory();
+  } else if (typeof define === 'function' && define.amd) {
+    // AMD loader
+    define('vertx-mail-js/mail_service-proxy', [], factory);
+  } else {
+    // plain old include
+    MailService = factory();
+  }
+}(function () {
+
+  /**
+
+ @class
+  */
+  var MailService = function(eb, address) {
+
+    var j_eb = eb;
+    var j_address = address;
+    var closed = false;
+    var that = this;
+    var convCharCollection = function(coll) {
+      var ret = [];
+      for (var i = 0;i < coll.length;i++) {
+        ret.push(String.fromCharCode(coll[i]));
+      }
+      return ret;
+    };
+  MailClient.call(this, j_val);
+
+    /**
+
+     @public
+     @param email {Object} 
+     @param resultHandler {function} 
+     @return {MailService}
+     */
+    this.sendMail = function(email, resultHandler) {
+      var __args = arguments;
+      if (__args.length === 2 && (typeof __args[0] === 'object' && __args[0] != null) && typeof __args[1] === 'function') {
+        if (closed) {
+          throw new Error('Proxy is closed');
+        }
+        j_eb.send(j_address, {"email":__args[0]}, {"action":"sendMail"}, function(err, result) { __args[1](err, result &&result.body); });
+        return that;
+      } else throw new TypeError('function invoked with invalid arguments');
+    };
+
+  };
+
+  /**
+   create a proxy of  MailService that delegates to the mail service running somewhere else via the event bus
+
+   @memberof module:vertx-mail-js/mail_service
+   @param vertx {Vertx} the Vertx instance the proxy will be run in 
+   @param address {string} the eb address of the mail service running somewhere, default is "vertx.mail" 
+   @return {MailService} MailService instance that can then be used to send multiple mails
+   */
+  MailService.createEventBusProxy = function(vertx, address) {
+    var __args = arguments;
+    if (__args.length === 2 && typeof __args[0] === 'object' && __args[0]._jdel && typeof __args[1] === 'string') {
+      if (closed) {
+        throw new Error('Proxy is closed');
+      }
+      j_eb.send(j_address, {"vertx":__args[0], "address":__args[1]}, {"action":"createEventBusProxy"});
+      return;
+    } else throw new TypeError('function invoked with invalid arguments');
+  };
+
+  if (typeof exports !== 'undefined') {
+    if (typeof module !== 'undefined' && module.exports) {
+      exports = module.exports = MailService;
+    } else {
+      exports.MailService = MailService;
+    }
+  } else {
+    return MailService;
+  }
+});

--- a/vertx-mail-service/src/main/resources/vertx-mail-js/mail_service.js
+++ b/vertx-mail-service/src/main/resources/vertx-mail-js/mail_service.js
@@ -44,7 +44,7 @@ var MailService = function(j_val) {
    */
   this.sendMail = function(email, resultHandler) {
     var __args = arguments;
-    if (__args.length === 2 && typeof __args[0] === 'object' && typeof __args[1] === 'function') {
+    if (__args.length === 2 && (typeof __args[0] === 'object' && __args[0] != null) && typeof __args[1] === 'function') {
       j_mailService["sendMail(io.vertx.ext.mail.MailMessage,io.vertx.core.Handler)"](email != null ? new MailMessage(new JsonObject(JSON.stringify(email))) : null, function(ar) {
       if (ar.succeeded()) {
         resultHandler(utils.convReturnDataObject(ar.result()), null);


### PR DESCRIPTION
moved isEsmtpSupported to Utils class, added unit test for the Utils method and a test in HeloTest
regenerated docs and generated js files

