### PR TITLE
fix#60 tab is a valid character in unencoded mail text

### DIFF
--- a/vertx-mail-client/src/main/java/io/vertx/ext/mail/mailencoder/Utils.java
+++ b/vertx-mail-client/src/main/java/io/vertx/ext/mail/mailencoder/Utils.java
@@ -72,13 +72,22 @@ class Utils {
     }
   }
 
+  /*
+   * check if a single char must be encoded as qp, this assumes we
+   * already have decided that we have to encode the text
+   */
   static boolean mustEncode(char ch) {
     return ch >= 128 || ch < 10 || ch >= 11 && ch < 32 || ch == '=';
   }
 
+  /*
+   * check if a String must be encoded as qp, this allows tab and = chars
+   * if these are there are no other chars to encode
+   */
   static boolean mustEncode(String s) {
     for (int i = 0; i < s.length(); i++) {
-      if (s.charAt(i) != '=' && mustEncode(s.charAt(i))) {
+      final char ch = s.charAt(i);
+      if (ch != '=' && ch != '\t' && mustEncode(ch)) {
         return true;
       }
     }

--- a/vertx-mail-client/src/test/java/io/vertx/ext/mail/mailencoder/MailEncoderTest.java
+++ b/vertx-mail-client/src/test/java/io/vertx/ext/mail/mailencoder/MailEncoderTest.java
@@ -502,4 +502,26 @@ public class MailEncoderTest {
     assertThat(mime, containsString("@myhostname.example.com"));
   }
 
+  /*
+   *  test that tabs not not turn on quoted-printable encoding unless there are
+   *  other chars that make it necessary 
+   */
+  @Test
+  public void testMailTextContainsTabs() throws Exception {
+    MailMessage message = new MailMessage();
+    message.setText("\t\n");
+    String mime = new MailEncoder(message, HOSTNAME).encode();
+    assertThat(mime, containsString("\t"));
+    assertThat(mime, not(containsString("=09")));
+  }
+
+  @Test
+  public void testMailTextContainsTabs2() throws Exception {
+    MailMessage message = new MailMessage();
+    message.setText("\tä\n");
+    String mime = new MailEncoder(message, HOSTNAME).encode();
+    assertThat(mime, not(containsString("\t")));
+    assertThat(mime, containsString("=09"));
+  }
+
 }


### PR DESCRIPTION
do not turn on quoted-printable encoding if the only char to be encoded in the text is tab
