### PR TITLE
Tls hostnamecheck missing

### DIFF
--- a/vertx-mail-client/pom.xml
+++ b/vertx-mail-client/pom.xml
@@ -31,4 +31,54 @@
     <doc.skip>false</doc.skip>
   </properties>
 
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>${maven.surefire.plugin.version}</version>
+          <configuration>
+            <failIfNoSpecifiedTests>false</failIfNoSpecifiedTests>
+            <systemPropertyVariables>
+              <buildDirectory>${project.build.directory}</buildDirectory>
+              <vertxVersion>${project.version}</vertxVersion>
+            </systemPropertyVariables>
+            <!-- Needs to be small enough to run in a EC2 1.7GB small instance -->
+            <!-- IMPORTANT: when modifying this line, don't forge to modify 
+              the same line in the`coverage` profile -->
+            <argLine>-Xmx1200M</argLine>
+            <forkCount>1</forkCount>
+            <reuseForks>true</reuseForks>
+            <excludes>
+              <exclude>io/vertx/ext/mail/MailLocal2Test.java</exclude>
+            </excludes>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+    <plugins>
+      <!-- Tests that require to run with different JVM settings -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <version>2.19.1</version>
+        <executions>
+          <execution>
+            <id>test</id>
+            <goals>
+              <goal>integration-test</goal>
+            </goals>
+            <phase>integration-test</phase>
+            <configuration>
+              <includes>
+                <include>io/vertx/ext/mail/MailLocal2Test.java</include>
+              </includes>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
 </project>

--- a/vertx-mail-client/src/main/java/io/vertx/ext/mail/impl/SMTPConnectionPool.java
+++ b/vertx-mail-client/src/main/java/io/vertx/ext/mail/impl/SMTPConnectionPool.java
@@ -26,6 +26,7 @@ import io.vertx.core.net.JksOptions;
 import io.vertx.core.net.NetClient;
 import io.vertx.core.net.NetClientOptions;
 import io.vertx.ext.mail.MailConfig;
+import io.vertx.ext.mail.StartTLSOptions;
 
 import java.util.ArrayDeque;
 import java.util.HashSet;
@@ -55,8 +56,8 @@ class SMTPConnectionPool implements ConnectionLifeCycleListener {
     maxSockets = config.getMaxPoolSize();
     keepAlive = config.isKeepAlive();
     NetClientOptions netClientOptions = new NetClientOptions().setSsl(config.isSsl()).setTrustAll(config.isTrustAll());
-    if(config.isSsl() && !config.isTrustAll()) {
-      // we can use HTTPS verification, which matches the requirements for SMTPS 
+    if ((config.isSsl() || config.getStarttls() != StartTLSOptions.DISABLED) && !config.isTrustAll()) {
+      // we can use HTTPS verification, which matches the requirements for SMTPS
       netClientOptions.setHostnameVerificationAlgorithm("HTTPS");
     }
     if (config.getKeyStore() != null) {

--- a/vertx-mail-client/src/test/java/io/vertx/ext/mail/MailLocal2Test.java
+++ b/vertx-mail-client/src/test/java/io/vertx/ext/mail/MailLocal2Test.java
@@ -24,11 +24,11 @@ import io.vertx.ext.unit.junit.VertxUnitRunner;
 
 /**
  * this test uses a different server keystore than MailLocalTest, so we need a new test class
- * 
+ *
  * @author <a href="http://oss.lehmann.cx/">Alexander Lehmann</a>
  */
 @RunWith(VertxUnitRunner.class)
-public class MailLocalTest2 extends SMTPTestWiser {
+public class MailLocal2Test extends SMTPTestWiser {
 
   @Test
   public void mailTestTLSValidCertWrongHost(TestContext testContext) {
@@ -39,6 +39,7 @@ public class MailLocalTest2 extends SMTPTestWiser {
     testException(mailClient);
   }
 
+  @Override
   protected void startSMTP() {
     super.startSMTP(KeyStoreSSLSocketFactory2.class.getName());
   }

--- a/vertx-mail-client/src/test/java/io/vertx/ext/mail/MailLocal2Test.java
+++ b/vertx-mail-client/src/test/java/io/vertx/ext/mail/MailLocal2Test.java
@@ -25,6 +25,9 @@ import io.vertx.ext.unit.junit.VertxUnitRunner;
 /**
  * this test uses a different server keystore than MailLocalTest, so we need a new test class
  *
+ * currently this test is run as integration-test (i.e. in a new jvm) since SSLSocketFactory.getDefault() isn't changed
+ * after it is used the first time and the test will fail if MailLocalTest is run before.
+ *
  * @author <a href="http://oss.lehmann.cx/">Alexander Lehmann</a>
  */
 @RunWith(VertxUnitRunner.class)

--- a/vertx-mail-client/src/test/java/io/vertx/ext/mail/MailLocalTest.java
+++ b/vertx-mail-client/src/test/java/io/vertx/ext/mail/MailLocalTest.java
@@ -16,7 +16,6 @@
 
 package io.vertx.ext.mail;
 
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 

--- a/vertx-mail-client/src/test/java/io/vertx/ext/mail/SMTPTestWiser.java
+++ b/vertx-mail-client/src/test/java/io/vertx/ext/mail/SMTPTestWiser.java
@@ -22,7 +22,6 @@ import java.util.List;
 
 import javax.mail.internet.MimeMessage;
 
-import org.slf4j.LoggerFactory;
 import org.subethamail.smtp.AuthenticationHandler;
 import org.subethamail.smtp.AuthenticationHandlerFactory;
 import org.subethamail.smtp.RejectException;
@@ -30,6 +29,9 @@ import org.subethamail.wiser.Wiser;
 import org.subethamail.wiser.WiserMessage;
 
 import static org.hamcrest.core.StringContains.containsString;
+
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
 
 /**
  * Start/stop a dummy test server for each test
@@ -39,6 +41,8 @@ import static org.hamcrest.core.StringContains.containsString;
  * @author <a href="http://oss.lehmann.cx/">Alexander Lehmann</a>
  */
 public class SMTPTestWiser extends SMTPTestBase {
+
+  private static final Logger log = LoggerFactory.getLogger(SMTPTestWiser.class);
 
   protected Wiser wiser;
 
@@ -61,7 +65,7 @@ public class SMTPTestWiser extends SMTPTestBase {
 
           @Override
           public String auth(final String clientInput) throws RejectException {
-            LoggerFactory.getLogger(this.getClass()).info(clientInput);
+            log.info(clientInput);
             return null;
           }
 

--- a/vertx-mail-client/src/test/java/io/vertx/ext/mail/impl/MailClientImpl2Test.java
+++ b/vertx-mail-client/src/test/java/io/vertx/ext/mail/impl/MailClientImpl2Test.java
@@ -29,9 +29,9 @@ import org.junit.runner.RunWith;
  * @author <a href="http://oss.lehmann.cx/">Alexander Lehmann</a>
  */
 @RunWith(VertxUnitRunner.class)
-public class MailClientImplTest2 extends SMTPTestWiser {
+public class MailClientImpl2Test extends SMTPTestWiser {
 
-  private static final Logger log = LoggerFactory.getLogger(MailClientImplTest2.class);
+  private static final Logger log = LoggerFactory.getLogger(MailClientImpl2Test.class);
 
   /**
    * test if we can shut down the connection pool while a send operation is still running the active connection will be


### PR DESCRIPTION
fixes #72 
set hostname checking for TLS required and optional
fixed 2 unit test names
changed one unit test to integration test to avoid SSLSocketFactory jvm problem
