### PR TITLE
fixes #77: when smtp connection is refused, the pool size count is wrong

### DIFF
--- a/vertx-mail-client/src/main/java/io/vertx/ext/mail/impl/SMTPConnection.java
+++ b/vertx-mail-client/src/main/java/io/vertx/ext/mail/impl/SMTPConnection.java
@@ -230,6 +230,8 @@ class SMTPConnection {
         ns.handler(mlp);
       } else {
         log.error("exception on connect", asyncResult.cause());
+        // notify the pool that the connection attempt didn't work so that the connection count is correct
+        listener.connectionClosed(null);
         handleError(asyncResult.cause());
       }
     });

--- a/vertx-mail-client/src/main/java/io/vertx/ext/mail/impl/SMTPConnectionPool.java
+++ b/vertx-mail-client/src/main/java/io/vertx/ext/mail/impl/SMTPConnectionPool.java
@@ -103,7 +103,7 @@ class SMTPConnectionPool implements ConnectionLifeCycleListener {
     checkReuseConnection(conn);
   }
 
-  // Called if the connection is actually closed, OR the connection attempt
+  // Called if the connection is actually closed OR the connection attempt
   // failed - in the latter case conn will be null
   public synchronized void connectionClosed(SMTPConnection conn) {
     log.debug("connection closed, removing from pool");
@@ -220,6 +220,7 @@ class SMTPConnectionPool implements ConnectionLifeCycleListener {
 
   private void createNewConnection(Handler<AsyncResult<SMTPConnection>> handler) {
     connCount++;
+    log.debug("Connection count is " + connCount);
     createConnection(result -> {
       if (result.succeeded()) {
         allConnections.add(result.result());

--- a/vertx-mail-client/src/test/java/io/vertx/ext/mail/impl/ConnectionErrorPoolTest.java
+++ b/vertx-mail-client/src/test/java/io/vertx/ext/mail/impl/ConnectionErrorPoolTest.java
@@ -1,0 +1,82 @@
+/*
+ *  Copyright (c) 2011-2016 The original author or authors
+ *
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  and Apache License v2.0 which accompanies this distribution.
+ *
+ *       The Eclipse Public License is available at
+ *       http://www.eclipse.org/legal/epl-v10.html
+ *
+ *       The Apache License v2.0 is available at
+ *       http://www.opensource.org/licenses/apache2.0.php
+ *
+ *  You may elect to redistribute this code under either of these licenses.
+ */
+
+package io.vertx.ext.mail.impl;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import io.vertx.ext.mail.MailClient;
+import io.vertx.ext.mail.MailConfig;
+import io.vertx.ext.mail.SMTPTestDummy;
+import io.vertx.ext.mail.impl.MailClientImpl;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+
+/**
+ * this is a test for issue https://github.com/vert-x3/vertx-mail-client/issues/77 when a connection fails (e.g. with
+ * connection refused), the pool size count is not decreased so that the connection pool is full after e.g. 10 failed
+ * connections. The test will just time out when the issue is present since the waiting connection never gets to run
+ *
+ * @author <a href="http://oss.lehmann.cx/">Alexander Lehmann</a>
+ */
+@RunWith(VertxUnitRunner.class)
+public class ConnectionErrorPoolTest extends SMTPTestDummy {
+
+  @Test
+  public void mailTest(TestContext testContext) {
+    Async async = testContext.async();
+
+    MailClient mailClient = MailClient.createNonShared(vertx, new MailConfig("localhost", 20025).setMaxPoolSize(1));
+
+    mailClient.sendMail(exampleMessage(), result -> {
+      testContext.assertTrue(result.failed());
+      mailClient.sendMail(exampleMessage(), result2 -> {
+        testContext.assertTrue(result2.failed());
+        async.complete();
+      });
+    });
+  }
+
+  /**
+   * when counting down the closed connection, make sure that we don't decrease the count twice for one connection  
+   */
+  @Test
+  public void countLessThan0Test(TestContext testContext) {
+    Async async = testContext.async();
+
+    smtpServer.setDialogue("500 connection rejected");
+
+    // since we want to spy on connCount, we have to use MailClientImpl directly
+    MailClientImpl mailClient = (MailClientImpl) MailClient.createNonShared(vertx, defaultConfig().setMaxPoolSize(1));
+    SMTPConnectionPool pool = mailClient.getConnectionPool();
+
+    testContext.assertTrue(pool.connCount()>=0, "connCount() is " + pool.connCount());
+
+    mailClient.sendMail(exampleMessage(), result -> {
+      testContext.assertTrue(result.failed());
+      testContext.assertTrue(pool.connCount()>=0, "connCount() is " + pool.connCount());
+
+      mailClient.sendMail(exampleMessage(), result2 -> {
+        testContext.assertTrue(result2.failed());
+        testContext.assertTrue(pool.connCount()>=0, "connCount() is " + pool.connCount());
+        async.complete();
+      });
+    });
+  }
+
+}

--- a/vertx-mail-client/src/test/java/io/vertx/ext/mail/impl/ConnectionErrorPoolTest.java
+++ b/vertx-mail-client/src/test/java/io/vertx/ext/mail/impl/ConnectionErrorPoolTest.java
@@ -38,7 +38,7 @@ import io.vertx.ext.unit.junit.VertxUnitRunner;
 public class ConnectionErrorPoolTest extends SMTPTestDummy {
 
   @Test
-  public void mailTest(TestContext testContext) {
+  public void poolCountRisesConnRefusedTest(TestContext testContext) {
     Async async = testContext.async();
 
     MailClient mailClient = MailClient.createNonShared(vertx, new MailConfig("localhost", 20025).setMaxPoolSize(1));


### PR DESCRIPTION
decrease pool conn count when connection fails
add unit test with pool size 1, this hangs when trying two consecutive connections
