### PR TITLE
fixes issue#82: attachment filenames with non US-ASCII characters are garbled

### DIFF
--- a/vertx-mail-client/src/main/java/io/vertx/ext/mail/mailencoder/AttachmentPart.java
+++ b/vertx-mail-client/src/main/java/io/vertx/ext/mail/mailencoder/AttachmentPart.java
@@ -31,8 +31,8 @@ class AttachmentPart extends EncodedPart {
       contentType = "application/octet-stream";
     }
     if (name != null) {
-      int index = contentType.length()+22;
-      contentType += "; name=\"" + Utils.encodeHeader(name, index)+ "\"";
+      int index = contentType.length() + 22;
+      contentType += "; name=\"" + Utils.encodeHeader(name, index) + "\"";
     }
     headers.set("Content-Type", contentType);
     headers.set("Content-Transfer-Encoding", "base64");
@@ -47,8 +47,8 @@ class AttachmentPart extends EncodedPart {
       disposition = "attachment";
     }
     if (name != null) {
-      int index = disposition.length()+33;
-      disposition += "; filename=\"" + Utils.encodeHeader(name, index) +"\"";
+      int index = disposition.length() + 33;
+      disposition += "; filename=\"" + Utils.encodeHeader(name, index) + "\"";
     }
     headers.set("Content-Disposition", disposition);
     if (attachment.getContentId() != null) {

--- a/vertx-mail-client/src/main/java/io/vertx/ext/mail/mailencoder/AttachmentPart.java
+++ b/vertx-mail-client/src/main/java/io/vertx/ext/mail/mailencoder/AttachmentPart.java
@@ -31,7 +31,8 @@ class AttachmentPart extends EncodedPart {
       contentType = "application/octet-stream";
     }
     if (name != null) {
-      contentType += "; name=" + name;
+      int index = contentType.length()+22;
+      contentType += "; name=\"" + Utils.encodeHeader(name, index)+ "\"";
     }
     headers.set("Content-Type", contentType);
     headers.set("Content-Transfer-Encoding", "base64");
@@ -46,7 +47,8 @@ class AttachmentPart extends EncodedPart {
       disposition = "attachment";
     }
     if (name != null) {
-      disposition += "; filename=" + name;
+      int index = disposition.length()+33;
+      disposition += "; filename=\"" + Utils.encodeHeader(name, index) +"\"";
     }
     headers.set("Content-Disposition", disposition);
     if (attachment.getContentId() != null) {

--- a/vertx-mail-client/src/test/java/io/vertx/ext/mail/mailencoder/MailEncoderTest.java
+++ b/vertx-mail-client/src/test/java/io/vertx/ext/mail/mailencoder/MailEncoderTest.java
@@ -398,16 +398,16 @@ public class MailEncoderTest {
       .setName("file.txt");
     message.setAttachment(attachment);
     String mime = new MailEncoder(message, HOSTNAME).encode();
-    assertThat(mime, containsString("Content-Type: application/x-something; name=file.txt"));
+    assertThat(mime, containsString("Content-Type: application/x-something; name=\"file.txt\""));
     assertThat(mime, containsString("Content-Description: description"));
-    assertThat(mime, containsString("Content-Disposition: attachment; filename=file.txt"));
+    assertThat(mime, containsString("Content-Disposition: attachment; filename=\"file.txt\""));
 
     BodyPart part = ((MimeMultipart) TestUtils.getMessage(mime).getContent()).getBodyPart(0);
     assertEquals("***", TestUtils.inputStreamToString(part.getInputStream()));
     assertEquals("attachment", part.getDisposition());
     assertEquals("file.txt", part.getFileName());
     assertEquals("description", part.getDescription());
-    assertEquals("application/x-something; name=file.txt", part.getContentType());
+    assertEquals("application/x-something; name=\"file.txt\"", part.getContentType());
   }
 
   @Test
@@ -577,6 +577,23 @@ public class MailEncoderTest {
     String encoded = new MailEncoder(email, HOSTNAME).encode();
     System.out.println(encoded);
     assertThat(encoded, containsString("Content-ID: image1@localhost"));
+  }
+
+  /*
+   * https://github.com/vert-x3/vertx-mail-client/issues/82
+   * attachment filename must be encoded
+   */
+  @Test
+  public void testAttachmentUtf8() {
+    MailMessage message = new MailMessage();
+    MailAttachment attachment = new MailAttachment();
+    attachment.setData(Buffer.buffer("test"));
+    attachment.setName("你好.txt");
+    message.setAttachment(attachment);
+    final MailEncoder encoder = new MailEncoder(message, HOSTNAME);
+    String mime = encoder.encode();
+    System.out.println(mime);
+    assertThat(mime, not(containsString("你好")));
   }
 
 }


### PR DESCRIPTION
add encoding of attachment filename when there are utf8 chars in the filename

