### PR TITLE
[fixes #96]

### DIFF
--- a/src/test/java/io/vertx/ext/mail/MailLocalTest.java
+++ b/src/test/java/io/vertx/ext/mail/MailLocalTest.java
@@ -19,7 +19,6 @@ package io.vertx.ext.mail;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import io.netty.handler.codec.DecoderException;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 
@@ -50,7 +49,7 @@ public class MailLocalTest extends SMTPTestWiser {
   public void mailTestTLSNoTrust(TestContext testContext) {
     this.testContext=testContext;
     MailClient mailClient = MailClient.createNonShared(vertx, configLogin().setStarttls(StartTLSOptions.REQUIRED));
-    testException(mailClient, DecoderException.class);
+    testException(mailClient);
   }
 
   @Test

--- a/src/test/java/io/vertx/ext/mail/MailValidCertWrongHostTest.java
+++ b/src/test/java/io/vertx/ext/mail/MailValidCertWrongHostTest.java
@@ -19,7 +19,6 @@ package io.vertx.ext.mail;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import io.netty.handler.codec.DecoderException;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 
@@ -41,7 +40,7 @@ public class MailValidCertWrongHostTest extends SMTPTestDummy {
     final MailConfig config = defaultConfig().setHostname("127.0.0.1").setPort(1587).setStarttls(StartTLSOptions.REQUIRED)
         .setKeyStore("src/test/resources/certs/client.jks").setKeyStorePassword("password");
     MailClient mailClient = MailClient.createNonShared(vertx, config);
-    testException(mailClient, DecoderException.class);
+    testException(mailClient);
   }
 
   @Test


### PR DESCRIPTION
check cert error exceptions with general exception instead of DecoderException as this doesn't work anymore. The actual error is connection closed.
