### PR TITLE
Feature: Add enabled secure transport protocols to MailConfig

### DIFF
--- a/src/main/java/io/vertx/ext/mail/MailConfig.java
+++ b/src/main/java/io/vertx/ext/mail/MailConfig.java
@@ -18,10 +18,9 @@ package io.vertx.ext.mail;
 
 import io.vertx.codegen.annotations.DataObject;
 import io.vertx.core.json.JsonObject;
+import io.vertx.core.net.NetClientOptions;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.Locale;
+import java.util.*;
 
 /**
  * represents the configuration of a mail service with mail server hostname,
@@ -39,6 +38,7 @@ public class MailConfig {
   public static final int DEFAULT_MAX_POOL_SIZE = 10;
   public static final boolean DEFAULT_SSL = false;
   public static final boolean DEFAULT_TRUST_ALL = false;
+  public static final Set<String> DEFAULT_SECURE_TRANSPORT_PROTOCOLS = new LinkedHashSet<>(NetClientOptions.DEFAULT_ENABLED_SECURE_TRANSPORT_PROTOCOLS);
   public static final boolean DEFAULT_ALLOW_RCPT_ERRORS = false;
   public static final boolean DEFAULT_KEEP_ALIVE = true;
   public static final boolean DEFAULT_DISABLE_ESMTP = false;
@@ -52,6 +52,7 @@ public class MailConfig {
   private String password;
   private boolean ssl = DEFAULT_SSL;
   private boolean trustAll = DEFAULT_TRUST_ALL;
+  private Set<String> enabledSecureTransportProtocols = DEFAULT_SECURE_TRANSPORT_PROTOCOLS;
   private String keyStore;
   private String keyStorePassword;
   private String ownHostname;
@@ -307,6 +308,25 @@ public class MailConfig {
    */
   public MailConfig setSsl(boolean ssl) {
     this.ssl = ssl;
+    return this;
+  }
+
+  /**
+   * Returns the enabled SSL/TLS protocols
+   * @return the enabled protocols
+   */
+  public Set<String> getEnabledSecureTransportProtocols() {
+    return new LinkedHashSet<>(enabledSecureTransportProtocols);
+  }
+
+  /**
+   * Sets the list of enabled SSL/TLS protocols.
+   *
+   * @param enabledSecureTransportProtocols  the SSL/TLS protocols to enable
+   * @return a reference to this, so the API can be used fluently
+   */
+  public MailConfig setEnabledSecureTransportProtocols(Set<String> enabledSecureTransportProtocols) {
+    this.enabledSecureTransportProtocols = enabledSecureTransportProtocols;
     return this;
   }
 

--- a/src/main/java/io/vertx/ext/mail/impl/SMTPConnectionPool.java
+++ b/src/main/java/io/vertx/ext/mail/impl/SMTPConnectionPool.java
@@ -55,7 +55,10 @@ class SMTPConnectionPool implements ConnectionLifeCycleListener {
     this.vertx = vertx;
     maxSockets = config.getMaxPoolSize();
     keepAlive = config.isKeepAlive();
-    NetClientOptions netClientOptions = new NetClientOptions().setSsl(config.isSsl()).setTrustAll(config.isTrustAll());
+    NetClientOptions netClientOptions = new NetClientOptions()
+      .setSsl(config.isSsl())
+      .setTrustAll(config.isTrustAll())
+      .setEnabledSecureTransportProtocols(config.getEnabledSecureTransportProtocols());
     if ((config.isSsl() || config.getStarttls() != StartTLSOptions.DISABLED) && !config.isTrustAll()) {
       // we can use HTTPS verification, which matches the requirements for SMTPS
       netClientOptions.setHostnameVerificationAlgorithm("HTTPS");

--- a/src/test/java/io/vertx/ext/mail/MailConfigTest.java
+++ b/src/test/java/io/vertx/ext/mail/MailConfigTest.java
@@ -19,6 +19,10 @@ package io.vertx.ext.mail;
 import io.vertx.core.json.JsonObject;
 import org.junit.Test;
 
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
 import static org.junit.Assert.*;
 
 public class MailConfigTest {
@@ -184,6 +188,14 @@ public class MailConfigTest {
     MailConfig mailConfig = new MailConfig();
     mailConfig.setSsl(true);
     assertTrue(mailConfig.isSsl());
+  }
+
+  @Test
+  public void testEnabledSecureTransportProtocols() {
+    Set<String> enabledProtocols = new LinkedHashSet<>(Arrays.asList("TLSv1"));
+    MailConfig mailConfig = new MailConfig();
+    mailConfig.setEnabledSecureTransportProtocols(enabledProtocols);
+    assertEquals(enabledProtocols, mailConfig.getEnabledSecureTransportProtocols());
   }
 
   @Test


### PR DESCRIPTION
# Motivation

I need to ensure that the communication between the SMTP client and server is done through TLSv1.2. However the `MailConfig` currently has no way of setting it.

# Change

I added the property to the `MailConfig` and propagate it to the `NetClientOptions` of the `SMTPConnectionPool`.

# Remarks

It might be worth considering to include `NetClientOptions` as a member of the `MailConfig` directly to avoid duplicating more and more code. I didn't do it here because it would be a major change and I wanted to get feedback first.