### PR TITLE
Make MailConfig a sub-class of NetClientOptions

### DIFF
--- a/src/main/asciidoc/dataobjects.adoc
+++ b/src/main/asciidoc/dataobjects.adoc
@@ -60,6 +60,9 @@ set string of allowed auth methods.
  if the server supports them. If null or empty all supported methods may be
  used
 +++
+|[[connectTimeout]]`@connectTimeout`|`Number (int)`|-
+|[[crlPaths]]`@crlPaths`|`Array of String`|-
+|[[crlValues]]`@crlValues`|`Array of Buffer`|-
 |[[disableEsmtp]]`@disableEsmtp`|`Boolean`|+++
 set if ESMTP should be tried as first command (EHLO)
  <p>
@@ -72,9 +75,15 @@ set if ESMTP should be tried as first command (EHLO)
  in that way, the property has to be set to false.
  <p>
 +++
+|[[enabledCipherSuites]]`@enabledCipherSuites`|`Array of String`|-
+|[[enabledSecureTransportProtocols]]`@enabledSecureTransportProtocols`|`Array of String`|-
 |[[hostname]]`@hostname`|`String`|+++
 Set the hostname of the smtp server.
 +++
+|[[hostnameVerificationAlgorithm]]`@hostnameVerificationAlgorithm`|`String`|-
+|[[idleTimeout]]`@idleTimeout`|`Number (int)`|-
+|[[idleTimeoutUnit]]`@idleTimeoutUnit`|`link:enums.html#TimeUnit[TimeUnit]`|-
+|[[jdkSslEngineOptions]]`@jdkSslEngineOptions`|`link:dataobjects.html#JdkSSLEngineOptions[JdkSSLEngineOptions]`|-
 |[[keepAlive]]`@keepAlive`|`Boolean`|+++
 set if connection pool is enabled
  default is true
@@ -88,9 +97,12 @@ get the key store filename to be used when opening SMTP connections
  if not set, an options object will be created based on other settings (ssl
  and trustAll)
 +++
+|[[keyStoreOptions]]`@keyStoreOptions`|`link:dataobjects.html#JksOptions[JksOptions]`|-
 |[[keyStorePassword]]`@keyStorePassword`|`String`|+++
 get the key store password to be used when opening SMTP connections
 +++
+|[[localAddress]]`@localAddress`|`String`|-
+|[[logActivity]]`@logActivity`|`Boolean`|-
 |[[login]]`@login`|`link:enums.html#LoginOption[LoginOption]`|+++
 Set the login mode for the connection.
  <p>
@@ -100,27 +112,45 @@ Set the login mode for the connection.
 set the max allowed number of open connections to the mail server
  if not set the default is 10
 +++
+|[[metricsName]]`@metricsName`|`String`|-
+|[[openSslEngineOptions]]`@openSslEngineOptions`|`link:dataobjects.html#OpenSSLEngineOptions[OpenSSLEngineOptions]`|-
 |[[ownHostname]]`@ownHostname`|`String`|+++
 set the hostname to be used for HELO/EHLO and the Message-ID
 +++
 |[[password]]`@password`|`String`|+++
 Set the password for the login.
 +++
+|[[pemKeyCertOptions]]`@pemKeyCertOptions`|`link:dataobjects.html#PemKeyCertOptions[PemKeyCertOptions]`|-
+|[[pemTrustOptions]]`@pemTrustOptions`|`link:dataobjects.html#PemTrustOptions[PemTrustOptions]`|-
+|[[pfxKeyCertOptions]]`@pfxKeyCertOptions`|`link:dataobjects.html#PfxOptions[PfxOptions]`|-
+|[[pfxTrustOptions]]`@pfxTrustOptions`|`link:dataobjects.html#PfxOptions[PfxOptions]`|-
 |[[port]]`@port`|`Number (int)`|+++
 Set the port of the smtp server.
 +++
-|[[ssl]]`@ssl`|`Boolean`|+++
-Set the sslOnConnect mode for the connection.
-+++
+|[[proxyOptions]]`@proxyOptions`|`link:dataobjects.html#ProxyOptions[ProxyOptions]`|-
+|[[receiveBufferSize]]`@receiveBufferSize`|`Number (int)`|-
+|[[reconnectAttempts]]`@reconnectAttempts`|`Number (int)`|-
+|[[reconnectInterval]]`@reconnectInterval`|`Number (long)`|-
+|[[reuseAddress]]`@reuseAddress`|`Boolean`|-
+|[[reusePort]]`@reusePort`|`Boolean`|-
+|[[sendBufferSize]]`@sendBufferSize`|`Number (int)`|-
+|[[soLinger]]`@soLinger`|`Number (int)`|-
+|[[ssl]]`@ssl`|`Boolean`|-
 |[[starttls]]`@starttls`|`link:enums.html#StartTLSOptions[StartTLSOptions]`|+++
 Set the tls security mode for the connection.
  <p>
  Either NONE, OPTIONAL or REQUIRED
 +++
-|[[trustAll]]`@trustAll`|`Boolean`|+++
-set whether to trust all certificates on ssl connect the option is also
- applied to STARTTLS operation
-+++
+|[[tcpCork]]`@tcpCork`|`Boolean`|-
+|[[tcpFastOpen]]`@tcpFastOpen`|`Boolean`|-
+|[[tcpKeepAlive]]`@tcpKeepAlive`|`Boolean`|-
+|[[tcpNoDelay]]`@tcpNoDelay`|`Boolean`|-
+|[[tcpQuickAck]]`@tcpQuickAck`|`Boolean`|-
+|[[trafficClass]]`@trafficClass`|`Number (int)`|-
+|[[trustAll]]`@trustAll`|`Boolean`|-
+|[[trustStoreOptions]]`@trustStoreOptions`|`link:dataobjects.html#JksOptions[JksOptions]`|-
+|[[useAlpn]]`@useAlpn`|`Boolean`|-
+|[[usePooledBuffers]]`@usePooledBuffers`|`Boolean`|-
 |[[username]]`@username`|`String`|+++
 Set the username for the login.
 +++

--- a/src/main/java/io/vertx/ext/mail/impl/SMTPConnectionPool.java
+++ b/src/main/java/io/vertx/ext/mail/impl/SMTPConnectionPool.java
@@ -22,9 +22,7 @@ import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
-import io.vertx.core.net.JksOptions;
 import io.vertx.core.net.NetClient;
-import io.vertx.core.net.NetClientOptions;
 import io.vertx.ext.mail.MailConfig;
 import io.vertx.ext.mail.StartTLSOptions;
 
@@ -55,17 +53,7 @@ class SMTPConnectionPool implements ConnectionLifeCycleListener {
     this.vertx = vertx;
     maxSockets = config.getMaxPoolSize();
     keepAlive = config.isKeepAlive();
-    NetClientOptions netClientOptions = new NetClientOptions().setSsl(config.isSsl()).setTrustAll(config.isTrustAll());
-    if ((config.isSsl() || config.getStarttls() != StartTLSOptions.DISABLED) && !config.isTrustAll()) {
-      // we can use HTTPS verification, which matches the requirements for SMTPS
-      netClientOptions.setHostnameVerificationAlgorithm("HTTPS");
-    }
-    if (config.getKeyStore() != null) {
-      // assume that password could be null if the keystore doesn't use one
-      netClientOptions.setTrustStoreOptions(new JksOptions().setPath(config.getKeyStore())
-          .setPassword(config.getKeyStorePassword()));
-    }
-    netClient = vertx.createNetClient(netClientOptions);
+    netClient = vertx.createNetClient(config);
   }
 
   void getConnection(String hostname, Handler<AsyncResult<SMTPConnection>> resultHandler) {

--- a/src/test/java/io/vertx/ext/mail/MailConfigTest.java
+++ b/src/test/java/io/vertx/ext/mail/MailConfigTest.java
@@ -26,8 +26,9 @@ public class MailConfigTest {
   @Test
   public void toJsonTest() {
     MailConfig mailConfig = new MailConfig();
-    assertEquals("{\"hostname\":\"localhost\",\"port\":25,\"starttls\":\"OPTIONAL\",\"login\":\"NONE\",\"maxPoolSize\":10}", mailConfig
-      .toJson().toString());
+    assertTrue(
+      mailConfig.toJson().toString()
+        .contains("\"hostname\":\"localhost\",\"port\":25,\"starttls\":\"OPTIONAL\",\"login\":\"NONE\",\"maxPoolSize\":10"));
   }
 
   @Test
@@ -44,28 +45,27 @@ public class MailConfigTest {
   @Test
   public void toJsonTest2() {
     MailConfig mailConfig = new MailConfig();
-    mailConfig.setUsername("username").setPassword("password").setSsl(true);
-    assertEquals(
-      "{\"hostname\":\"localhost\",\"port\":25,\"starttls\":\"OPTIONAL\",\"login\":\"NONE\",\"username\":\"username\",\"password\":\"password\",\"ssl\":true,\"maxPoolSize\":10}",
-      mailConfig.toJson().toString());
+    mailConfig.setUsername("username").setPassword("password");
+    assertTrue(
+      mailConfig.toJson().toString()
+        .contains("\"hostname\":\"localhost\",\"port\":25,\"starttls\":\"OPTIONAL\",\"login\":\"NONE\",\"username\":\"username\",\"password\":\"password\",\"maxPoolSize\":10"));
   }
 
   @Test
   public void toJsonTest3() {
     MailConfig mailConfig = new MailConfig();
     mailConfig.setHostname(null).setPort(0).setStarttls(null).setLogin(null);
-    assertEquals("{\"port\":0,\"maxPoolSize\":10}", mailConfig.toJson().toString());
+    assertTrue(mailConfig.toJson().toString().contains("\"port\":0,\"maxPoolSize\":10"));
   }
 
   @Test
   public void toJsonTest4() {
     MailConfig mailConfig = new MailConfig();
-    mailConfig.setTrustAll(true);
     mailConfig.setAuthMethods("PLAIN");
     mailConfig.setOwnHostname("example.com");
-    assertEquals(
-      "{\"hostname\":\"localhost\",\"port\":25,\"starttls\":\"OPTIONAL\",\"login\":\"NONE\",\"trustAll\":true,\"authMethods\":\"PLAIN\",\"ownHostname\":\"example.com\",\"maxPoolSize\":10}",
-      mailConfig.toJson().toString());
+    assertTrue(
+      mailConfig.toJson().toString()
+        .contains("\"hostname\":\"localhost\",\"port\":25,\"starttls\":\"OPTIONAL\",\"login\":\"NONE\",\"authMethods\":\"PLAIN\",\"ownHostname\":\"example.com\",\"maxPoolSize\":10"));
   }
 
   @Test
@@ -74,19 +74,9 @@ public class MailConfigTest {
     mailConfig.setKeepAlive(false);
     mailConfig.setAllowRcptErrors(true);
     mailConfig.setDisableEsmtp(true);
-    assertEquals(
-      "{\"hostname\":\"localhost\",\"port\":25,\"starttls\":\"OPTIONAL\",\"login\":\"NONE\",\"maxPoolSize\":10,\"keepAlive\":false,\"allowRcptErrors\":true,\"disableEsmtp\":true}",
-      mailConfig.toJson().toString());
-  }
-
-  @Test
-  public void toJsonTest6() {
-    MailConfig mailConfig = new MailConfig();
-    mailConfig.setKeyStore("keyStore");
-    mailConfig.setKeyStorePassword("keyStorePassword");
-    assertEquals(
-      "{\"hostname\":\"localhost\",\"port\":25,\"starttls\":\"OPTIONAL\",\"login\":\"NONE\",\"keyStore\":\"keyStore\",\"keyStorePassword\":\"keyStorePassword\",\"maxPoolSize\":10}",
-      mailConfig.toJson().toString());
+    assertTrue(
+      mailConfig.toJson().toString()
+        .contains("\"hostname\":\"localhost\",\"port\":25,\"starttls\":\"OPTIONAL\",\"login\":\"NONE\",\"maxPoolSize\":10,\"keepAlive\":false,\"allowRcptErrors\":true,\"disableEsmtp\":true"));
   }
 
   @Test
@@ -103,16 +93,16 @@ public class MailConfigTest {
   public void newJsonEmptyTest() {
     JsonObject json = new JsonObject("{}");
     MailConfig mailConfig = new MailConfig(json);
-    assertEquals("{\"hostname\":\"localhost\",\"port\":25,\"starttls\":\"OPTIONAL\",\"login\":\"NONE\"," +
-        "\"maxPoolSize\":10}", mailConfig.toJson().encode());
+    assertEquals(mailConfig, new MailConfig());
   }
 
   @Test
   public void testConstructorFromMailConfig() {
     MailConfig mailConfig = new MailConfig();
     mailConfig.setHostname("asdfasdf").setPort(1234);
-    assertEquals("{\"hostname\":\"asdfasdf\",\"port\":1234,\"starttls\":\"OPTIONAL\",\"login\":\"NONE\",\"maxPoolSize\":10}",
-      new MailConfig(mailConfig).toJson().encode());
+    MailConfig fromConfig = new MailConfig(mailConfig);
+    assertEquals(fromConfig.getHostname(), "asdfasdf");
+    assertEquals(fromConfig.getPort(), 1234);
   }
 
   @Test


### PR DESCRIPTION
This allows for the setting of all of the options used to create the
connection to the SMTP server and not just the few that were exposed by
the MailConfig class.

Fixes #79