### PR TITLE
Update docs about userAgent for MailConfig

### DIFF
--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -178,6 +178,7 @@ The configuration has the following properties
 * `keyStorePassword` String password used to decrypt the key store (optional)
 * `allowRcptErrors` boolean if true, sending continues if a recipient address is not accepted and the mail will be sent if at least one address is accepted (default false)
 * `disableEsmtp` boolean if true, ESMTP-related commands will not be used (set if your smtp server doesn't even give a proper error response code for the EHLO command) (default false)
+* `userAgent` String represents the Mail User Agent(MUA) name used to generate email boundaries for multipart emails and message-id, default is `vertxmail`.
 
 === MailResult object
 The MailResult object has the following members


### PR DESCRIPTION
Fixes: https://github.com/vert-x3/vertx-mail-client/issues/111

This is the missing docs update to introduce `userAgent` to `MailConfig`.