### PR TITLE
[Issue-102] implement DKIM signature

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,6 +112,19 @@
       <version>1.2.17</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.james.jdkim</groupId>
+      <artifactId>apache-jdkim-library</artifactId>
+      <version>0.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.james.jdkim</groupId>
+      <artifactId>apache-jdkim-library</artifactId>
+      <version>0.2</version>
+      <classifier>tests</classifier>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/asciidoc/dataobjects.adoc
+++ b/src/main/asciidoc/dataobjects.adoc
@@ -1,5 +1,63 @@
 = Cheatsheets
 
+[[DKIMSignOptions]]
+== DKIMSignOptions
+
+++++
+
+ This represents the options used to perform DKIM Signature signing action.
+
+ See: https://tools.ietf.org/html/rfc6376
+++++
+'''
+
+[cols=">25%,25%,50%"]
+[frame="topbot"]
+|===
+^|Name | Type ^| Description
+|[[auid]]`@auid`|`String`|+++
+Sets the Agent or User Identifier(AUID)
++++
+|[[bodyCanonic]]`@bodyCanonic`|`link:enums.html#MessageCanonic[MessageCanonic]`|+++
+Sets the message canonicalization for email body.
++++
+|[[bodyLimit]]`@bodyLimit`|`Number (int)`|+++
+Sets the body limit to sign.
++++
+|[[copiedHeaders]]`@copiedHeaders`|`Array of String`|+++
+Sets the copied headers used in DKIM.
++++
+|[[expireTime]]`@expireTime`|`Number (long)`|+++
+Sets the expire time in seconds when the signature sign will be expired.
+
+ Success call of this method indicates that the signature sign timestamp is enabled.
++++
+|[[headerCanonic]]`@headerCanonic`|`link:enums.html#MessageCanonic[MessageCanonic]`|+++
+Sets the message canonicalization for email signedHeaders.
++++
+|[[privateKey]]`@privateKey`|`String`|+++
+Sets the PKCS#8 format private key used to sign the email.
++++
+|[[privateKeyPath]]`@privateKeyPath`|`String`|+++
+Sets the PKCS#8 format private key file path.
++++
+|[[sdid]]`@sdid`|`String`|+++
+Sets the Singing Domain Identifier(SDID).
++++
+|[[selector]]`@selector`|`String`|+++
+Sets the selector used to query the public key.
++++
+|[[signAlgo]]`@signAlgo`|`link:enums.html#DKIMSignAlgorithm[DKIMSignAlgorithm]`|+++
+Sets the signing algorithm.
++++
+|[[signatureTimestamp]]`@signatureTimestamp`|`Boolean`|+++
+Sets to enable or disable signature sign timestmap. Default is disabled.
++++
+|[[signedHeaders]]`@signedHeaders`|`Array of String`|+++
+Sets the email signedHeaders used to sign.
++++
+|===
+
 [[MailConfig]]
 == MailConfig
 
@@ -36,6 +94,19 @@ set if ESMTP should be tried as first command (EHLO)
  smtp hosts on the internet. Since the client knows that is connects to a host that doesn't support ESMTP/EHLO
  in that way, the property has to be set to false.
  <p>
++++
+|[[dkimSignOption]]`@dkimSignOption`|`link:dataobjects.html#DKIMSignOptions[DKIMSignOptions]`|+++
+Sets one DKIMSignOptions for convenient.
++++
+|[[dkimSignOptions]]`@dkimSignOptions`|`Array of link:dataobjects.html#DKIMSignOptions[DKIMSignOptions]`|+++
+Sets DKIMSignOptions.
++++
+|[[enableDKIM]]`@enableDKIM`|`Boolean`|+++
+Sets true to enable DKIM Signatures, sets false to disable it.
+
+ <p>
+     This is used most for temporary disable DKIM without removing DKIM opations from current config.
+ </p>
 +++
 |[[enabledSecureTransportProtocols]]`@enabledSecureTransportProtocols`|`Array of String`|+++
 Sets the list of enabled SSL/TLS protocols.

--- a/src/main/asciidoc/enums.adoc
+++ b/src/main/asciidoc/enums.adoc
@@ -1,0 +1,36 @@
+= Enums
+
+[[DKIMSignAlgorithm]]
+== DKIMSignAlgorithm
+
+++++
+
+ Signing Algorithm specified by DKIM spec.
+++++
+'''
+
+[cols=">25%,75%"]
+[frame="topbot"]
+|===
+^|Name | Description
+|[[RSA_SHA1]]`RSA_SHA1`|-
+|[[RSA_SHA256]]`RSA_SHA256`|-
+|===
+
+[[MessageCanonic]]
+== MessageCanonic
+
+++++
+
+ Message canonicalization for DKIM.
+++++
+'''
+
+[cols=">25%,75%"]
+[frame="topbot"]
+|===
+^|Name | Description
+|[[SIMPLE]]`SIMPLE`|-
+|[[RELAXED]]`RELAXED`|-
+|===
+

--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -116,6 +116,38 @@ A mail is sent as follows:
 {@link examples.MailExamples#sendMail}
 ----
 
+== DKIM Signature Signing emails
+
+It supports http://dkim.org[DomainKeys Identified Mail (DKIM)] Signature signing to secure your emails. All you need to
+do is to specify required configurations to sign your email.
+
+A mail client with DKIM feature enabled can be created as follows:
+
+[source,$lang]
+----
+{@link examples.MailExamples#createDKIMMailClient}
+----
+
+After the mail client is created, each `mailClient.sendMail` call will have the email signed by adding additional
+`DKIM-Signature` header.
+
+=== Caching the Attachment Streams used in DKIM
+
+To be able to perform DKIM sign, it needs to hash the email's body, including attachments.
+If an attachment comes from a ReadStream, it won't be able to go through again. So we need
+to cache the attachment data. This client provides 2 strategies to cache it.
+
+* In memory caching
+
+By default, the stream content is cached in memory so it can be sent later.
+
+* Caching in a temporary file
+
+You can cache data from attachment's Stream to a temporary file by specifying a system property:
+`vertx.mail.attachment.cache.file` to `true` for large attachments. It will try to delete the temporary file
+after each send.
+
+
 == Mail-client data objects
 
 === MailMessage properties
@@ -179,9 +211,28 @@ The configuration has the following properties
 * `allowRcptErrors` boolean if true, sending continues if a recipient address is not accepted and the mail will be sent if at least one address is accepted (default false)
 * `disableEsmtp` boolean if true, ESMTP-related commands will not be used (set if your smtp server doesn't even give a proper error response code for the EHLO command) (default false)
 * `userAgent` String represents the Mail User Agent(MUA) name used to generate email boundaries for multipart emails and message-id, default is `vertxmail`.
+* `enableDKIM` boolean if true, the DKIM signing will be enabled if DKIM configurations are set as well, default is `false`.
+* `dkimSignOptions` List of `DKIMSignOptions` which are used to perform the DKIM sign.
 
 === MailResult object
 The MailResult object has the following members
 
 * `messageID` the Message-ID of the generated mail
 * `recipients` the list of recipients the mail was sent to (if allowRcptErrors is true, this may be fewer than the intended recipients)
+
+=== DKIMSignOptions object
+The DKIMSignOptions object has the following properties
+
+* `privateKey` The RSA https://www.ietf.org/rfc/rfc5208.txt[PKCS#8] format private key used to sign the emails.
+* `privateKeyPath` The file path where the RSA https://www.ietf.org/rfc/rfc5208.txt[PKCS#8] format private key is specified. Either `privateKey` or `privateKeyPath` is *required*.
+* `signAlgo` either `DKIMSignAlgorithm.RSA_SHA256`(default) or `DKIMSignAlgorithm.RSA_SHA1`. The algorithm used to do the body hashing and signature sign.
+* `signedHeaders` List of String that specify which email headers will be used to perform the sign. Defaults: `From`, `Reply-to`, `Subject`, `Date`, `To`, `Cc`. Note: the order matters.
+* `sdid` *required*, String, Singing Domain Identifier(SDID), normally it is the domain of the SMTP server.
+* `auid` optional, String, the Agent or User Identifier(AUID), default is `@` plus `sdid`
+* `selector` *required*, String, the selector used to query public key.
+* `headerCanonic` MessageCanonic algorithm used for headers, one of `simple`(default) and `relaxed`.
+* `bodyCanonic` MessageCanonic algorithm used for body hashing, one of `simple`(default) and `relaxed`.
+* `bodyLimit` optional, int, how long of the body used to calculate the body hash.
+* `signatureTimestamp` optional, boolean, if includes timestamp in the `DKIM-SIgnature` tags list. default is false
+* `expireTime` optional, long, expire time in seconds when the signature sign will be expired from now.
+* `copiedHeaders` optional, List of strings, the copied headers used in DKIM. Usually they are used for debug purpose according to the DKIM spec.

--- a/src/main/java/examples/MailExamples.java
+++ b/src/main/java/examples/MailExamples.java
@@ -19,11 +19,7 @@ package examples;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.docgen.Source;
-import io.vertx.ext.mail.MailAttachment;
-import io.vertx.ext.mail.MailClient;
-import io.vertx.ext.mail.MailConfig;
-import io.vertx.ext.mail.MailMessage;
-import io.vertx.ext.mail.StartTLSOptions;
+import io.vertx.ext.mail.*;
 
 /**
  * code chunks for the adoc documentation
@@ -78,6 +74,16 @@ public class MailExamples {
     attachment.setContentId("<image1@example.com>");
 
     message.setInlineAttachment(attachment);
+  }
+
+  public void createDKIMMailClient(Vertx vertx) {
+    DKIMSignOptions dkimSignOptions = new DKIMSignOptions();
+    dkimSignOptions.setPrivateKey("PKCS8 Private Key Base64 String");
+    dkimSignOptions.setAuid("identifier@example.com");
+    dkimSignOptions.setSelector("selector");
+    dkimSignOptions.setSdid("example.com");
+    MailConfig config = new MailConfig().setDKIMSignOption(dkimSignOptions).setEnableDKIM(true);
+    MailClient mailClient = MailClient.createShared(vertx, config);
   }
 
   public void sendMail(MailMessage message, MailClient mailClient) {

--- a/src/main/java/io/vertx/ext/mail/DKIMSignAlgorithm.java
+++ b/src/main/java/io/vertx/ext/mail/DKIMSignAlgorithm.java
@@ -1,0 +1,91 @@
+/*
+ *  Copyright (c) 2011-2019 The original author or authors
+ *
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  and Apache License v2.0 which accompanies this distribution.
+ *
+ *       The Eclipse Public License is available at
+ *       http://www.eclipse.org/legal/epl-v10.html
+ *
+ *       The Apache License v2.0 is available at
+ *       http://www.opensource.org/licenses/apache2.0.php
+ *
+ *  You may elect to redistribute this code under either of these licenses.
+ */
+
+package io.vertx.ext.mail;
+
+import io.vertx.codegen.annotations.VertxGen;
+
+/**
+ *
+ * Signing Algorithm specified by DKIM spec.
+ *
+ * @author <a href="mailto: aoingl@gmail.com">Lin Gao</a>
+ */
+@VertxGen
+public enum DKIMSignAlgorithm {
+  RSA_SHA1("sha1", "rsa", "SHA-1"), // rsa-sha1
+  RSA_SHA256("sha256", "rsa", "SHA-256"); // rsa-sha256
+
+  /**
+   * The hash algorithm id used by {@link io.vertx.ext.auth.HashingAlgorithm} to distinguish from others.
+   */
+  private String hashAlgoId;
+
+  /**
+   * The Hash type. It is: <code>rsa</code> now.
+   */
+  private String type;
+
+  /**
+   * The actual algorithm that can be used by the {@link java.security.MessageDigest} to calculate the digest.
+   */
+  private String hashAlgo;
+
+  DKIMSignAlgorithm(String hashAlgoId, String type, String hashAlgo) {
+    this.hashAlgoId = hashAlgoId;
+    this.type = type;
+    this.hashAlgo = hashAlgo;
+  }
+
+  /**
+   * Gets the algorithm name specified by the DKIM specification.
+   *
+   * See: https://tools.ietf.org/html/rfc6376#section-3.3
+   *
+   * @return the algorithm name
+   */
+  public String dkimAlgoName() {
+    return this.type + "-" + this.hashAlgoId;
+  }
+
+  /**
+   * Gets the hash algorithm to produce the hash of the message.
+   *
+   * @return the hash algorithm
+   */
+  public String hashAlgorithm() {
+    return this.hashAlgo;
+  }
+
+  /**
+   * Gets the Hash Algorithm ID that can be identified by the {@link io.vertx.ext.auth.HashingStrategy}.
+   *
+   * @return the id of the Hash Algorithm.
+   */
+  public String hashAlgoId() {
+    return hashAlgoId;
+  }
+
+  /**
+   * Gets the Signature Algorithm, like: SHA256withRSA, SHA1withRSA.
+   *
+   * @return the signature algorithm
+   */
+  public String signatureAlgorithm() {
+    return this.hashAlgoId.toUpperCase() + "with" + this.type.toUpperCase();
+  }
+
+}

--- a/src/main/java/io/vertx/ext/mail/DKIMSignOptions.java
+++ b/src/main/java/io/vertx/ext/mail/DKIMSignOptions.java
@@ -1,0 +1,449 @@
+/*
+ *  Copyright (c) 2011-2019 The original author or authors
+ *
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  and Apache License v2.0 which accompanies this distribution.
+ *
+ *       The Eclipse Public License is available at
+ *       http://www.eclipse.org/legal/epl-v10.html
+ *
+ *       The Apache License v2.0 is available at
+ *       http://www.opensource.org/licenses/apache2.0.php
+ *
+ *  You may elect to redistribute this code under either of these licenses.
+ */
+
+package io.vertx.ext.mail;
+
+import io.vertx.codegen.annotations.DataObject;
+import io.vertx.core.json.JsonObject;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+
+/**
+ *
+ * This represents the options used to perform DKIM Signature signing action.
+ *
+ * See: https://tools.ietf.org/html/rfc6376
+ *
+ * @author <a href="mailto: aoingl@gmail.com">Lin Gao</a>
+ */
+@DataObject(generateConverter = true)
+public class DKIMSignOptions {
+
+  private static final List<String> DEFAULT_HEADERS = new ArrayList<>();
+  static {
+    DEFAULT_HEADERS.add("From");
+    DEFAULT_HEADERS.add("Reply-to");
+    DEFAULT_HEADERS.add("Subject");
+    DEFAULT_HEADERS.add("Date");
+    DEFAULT_HEADERS.add("To");
+    DEFAULT_HEADERS.add("Cc");
+    DEFAULT_HEADERS.add("Content-Type");
+    DEFAULT_HEADERS.add("Message-ID");
+  }
+
+  private String privateKey;
+  private String privateKeyPath;
+
+  private DKIMSignAlgorithm signAlgo = DKIMSignAlgorithm.RSA_SHA256;
+  private List<String> signedHeaders;
+  private String sdid;
+  private String auid;
+  private String selector;
+  private MessageCanonic headerCanonic = MessageCanonic.SIMPLE;
+  private MessageCanonic bodyCanonic = MessageCanonic.SIMPLE;
+  private int bodyLimit = -1;
+  private boolean signatureTimestamp;
+  private long expireTime = -1L;
+  private List<String> copiedHeaders;
+
+  /**
+   * Default Constructor.
+   */
+  public DKIMSignOptions() {
+    signedHeaders = new ArrayList<>(DEFAULT_HEADERS);
+  }
+
+  public DKIMSignOptions (DKIMSignOptions other) {
+    privateKey = other.privateKey;
+    privateKeyPath = other.privateKeyPath;
+    signAlgo = other.signAlgo;
+    if (other.signedHeaders != null && !other.signedHeaders.isEmpty()) {
+      signedHeaders = new ArrayList<>(other.signedHeaders);
+    } else {
+      signedHeaders = new ArrayList<>(DEFAULT_HEADERS);
+    }
+    sdid = other.sdid;
+    auid = other.auid;
+    selector = other.selector;
+    headerCanonic = other.headerCanonic;
+    bodyCanonic = other.bodyCanonic;
+    bodyLimit = other.bodyLimit;
+    signatureTimestamp = other.signatureTimestamp;
+    expireTime = other.expireTime;
+    if (other.copiedHeaders != null && !other.copiedHeaders.isEmpty()) {
+      copiedHeaders = new ArrayList<>(other.copiedHeaders);
+    }
+  }
+
+  /**
+   * Constructor from a JsonObject.
+   *
+   * @param config the JsonObject configuration
+   */
+  public DKIMSignOptions(JsonObject config) {
+    DKIMSignOptionsConverter.fromJson(config, this);
+    if (signedHeaders == null || signedHeaders.isEmpty()) {
+      signedHeaders = new ArrayList<>(DEFAULT_HEADERS);
+    }
+  }
+
+  /**
+   * Converts to JsonObject
+   *
+   * @return the JsonObject which represents current configuration.
+   */
+  public JsonObject toJson() {
+    JsonObject json = new JsonObject();
+    DKIMSignOptionsConverter.toJson(this, json);
+    return json;
+  }
+
+  /**
+   * Gets the signing algorithm.
+   *
+   * @return the signing algorithm
+   */
+  public DKIMSignAlgorithm getSignAlgo() {
+    return signAlgo;
+  }
+
+  /**
+   * Gets the PKCS#8 format private key used to sign the email.
+   *
+   * @return the private key
+   */
+  public String getPrivateKey() {
+    return privateKey;
+  }
+
+  /**
+   * Sets the PKCS#8 format private key used to sign the email.
+   *
+   * @param privateKey the base64 encdoing private key content.
+   * @return a reference to this, so the API can be used fluently
+   */
+  public DKIMSignOptions setPrivateKey(String privateKey) {
+    this.privateKey = privateKey;
+    return this;
+  }
+
+  /**
+   * Gets the PKCS#8 format private key file path.
+   *
+   * @return the PKCS#8 format private key file path.
+   */
+  public String getPrivateKeyPath() {
+    return privateKeyPath;
+  }
+
+  /**
+   * Sets the PKCS#8 format private key file path.
+   *
+   * @param privateKeyPath The PKCS#8 format private key file path.
+   * @return a reference to this, so the API can be used fluently
+   */
+  public DKIMSignOptions setPrivateKeyPath(String privateKeyPath) {
+    this.privateKeyPath = privateKeyPath;
+    return this;
+  }
+
+  /**
+   * Sets the signing algorithm.
+   *
+   * @param signAlgo the signing algorithm
+   * @return a reference to this, so the API can be used fluently
+   */
+  public DKIMSignOptions setSignAlgo(DKIMSignAlgorithm signAlgo) {
+    this.signAlgo = signAlgo;
+    return this;
+  }
+
+  /**
+   * Gets the email signedHeaders used to sign.
+   *
+   * The order in the list matters.
+   *
+   * @return the email signedHeaders used to sign
+   */
+  public List<String> getSignedHeaders() {
+    return signedHeaders;
+  }
+
+  /**
+   * Sets the email signedHeaders used to sign.
+   *
+   * @param signedHeaders the email signedHeaders
+   * @return a reference to this, so the API can be used fluently
+   */
+  public DKIMSignOptions setSignedHeaders(List<String> signedHeaders) {
+    this.signedHeaders = signedHeaders;
+    return this;
+  }
+
+  /**
+   * Adds the signed header
+   *
+   * @param header the header name
+   * @return a reference to this, so the API can be used fluently
+   */
+  public DKIMSignOptions addSignedHeader(String header) {
+    if (this.signedHeaders == null) {
+      this.signedHeaders = new ArrayList<>();
+    }
+    this.signedHeaders.add(header);
+    return this;
+  }
+
+  /**
+   * Gets the Singing Domain Identifier(SDID).
+   *
+   * @return the signing domain identifier
+   */
+  public String getSdid() {
+    return sdid;
+  }
+
+  /**
+   * Sets the Singing Domain Identifier(SDID).
+   *
+   * @param sdid the signing domain identifier
+   * @return a reference to this, so the API can be used fluently
+   */
+  public DKIMSignOptions setSdid(String sdid) {
+    this.sdid = sdid;
+    return this;
+  }
+
+  /**
+   * Gets the selector used to query public key.
+   *
+   * @return the selector
+   */
+  public String getSelector() {
+    return selector;
+  }
+
+  /**
+   * Sets the selector used to query the public key.
+   *
+   * @param selector the selector
+   * @return a reference to this, so the API can be used fluently
+   */
+  public DKIMSignOptions setSelector(String selector) {
+    this.selector = selector;
+    return this;
+  }
+
+  /**
+   * Gets the signedHeaders message canonicalization.
+   *
+   * @return the message canonicalization for the email signedHeaders
+   */
+  public MessageCanonic getHeaderCanonic() {
+    return headerCanonic;
+  }
+
+  /**
+   * Sets the message canonicalization for email signedHeaders.
+   *
+   * @param headerCanonic the message canonicalization for email signedHeaders
+   * @return a reference to this, so the API can be used fluently
+   */
+  public DKIMSignOptions setHeaderCanonic(MessageCanonic headerCanonic) {
+    this.headerCanonic = headerCanonic;
+    return this;
+  }
+
+  /**
+   * Gets the email body message canonicalization.
+   *
+   * @return the message canonicalization for the email body
+   */
+  public MessageCanonic getBodyCanonic() {
+    return bodyCanonic;
+  }
+
+  /**
+   * Sets the message canonicalization for email body.
+   *
+   * @param bodyCanonic the message canonicalization for email body
+   * @return a reference to this, so the API can be used fluently
+   */
+  public DKIMSignOptions setBodyCanonic(MessageCanonic bodyCanonic) {
+    this.bodyCanonic = bodyCanonic;
+    return this;
+  }
+
+  /**
+   * Gets the Agent or User Identifier(AUID)
+   *
+   * @return the auid
+   */
+  public String getAuid() {
+    return auid;
+  }
+
+  /**
+   * Sets the Agent or User Identifier(AUID)
+   *
+   * @param auid the AUID
+   * @return a reference to this, so the API can be used fluently
+   */
+  public DKIMSignOptions setAuid(String auid) {
+    this.auid = auid;
+    return this;
+  }
+
+  /**
+   * Gets the body limit to sign.
+   *
+   * @return the body limit
+   */
+  public int getBodyLimit() {
+    return bodyLimit;
+  }
+
+  /**
+   * Sets the body limit to sign.
+   *
+   * @param bodyLimit the body limit
+   * @return a reference to this, so the API can be used fluently
+   */
+  public DKIMSignOptions setBodyLimit(int bodyLimit) {
+    if (bodyLimit <= 0) {
+      throw new IllegalArgumentException("Body Limit to calculate the hash must be larger than 0");
+    }
+    this.bodyLimit = bodyLimit;
+    return this;
+  }
+
+  /**
+   * Adds signature sign timestamp or not.
+   *
+   * @return true if yes, false otherwise
+   */
+  public boolean isSignatureTimestamp() {
+    return signatureTimestamp;
+  }
+
+  /**
+   * Sets to enable or disable signature sign timestmap. Default is disabled.
+   *
+   * @param signatureTimestamp if enable signature sign timestamp or not
+   * @return a reference to this, so the API can be used fluently
+   */
+  public DKIMSignOptions setSignatureTimestamp(boolean signatureTimestamp) {
+    this.signatureTimestamp = signatureTimestamp;
+    return this;
+  }
+
+  /**
+   * Gets the expire time in seconds when the signature sign will be expired.
+   *
+   * @return expire time of signature. Positive value means the signature sign timestamp is enabled.
+   */
+  public long getExpireTime() {
+    return expireTime;
+  }
+
+  /**
+   * Sets the expire time in seconds when the signature sign will be expired.
+   *
+   * Success call of this method indicates that the signature sign timestamp is enabled.
+   *
+   * @param expireTime the expire time in seconds
+   * @return a reference to this, so the API can be used fluently
+   */
+  public DKIMSignOptions setExpireTime(long expireTime) {
+    if (expireTime <= 0) {
+      throw new IllegalArgumentException("Expire time must be larger than 0");
+    }
+    this.expireTime = expireTime;
+    return this;
+  }
+
+  /**
+   * Gets the copied headers used in DKIM.
+   *
+   * @return the copied headers
+   */
+  public List<String> getCopiedHeaders() {
+    return copiedHeaders;
+  }
+
+  /**
+   * Sets the copied headers used in DKIM.
+   *
+   * @param copiedHeaders the copied headers
+   * @return a reference to this, so the API can be used fluently
+   */
+  public DKIMSignOptions setCopiedHeaders(List<String> copiedHeaders) {
+    this.copiedHeaders = copiedHeaders;
+    return this;
+  }
+
+  /**
+   * Adds a copied header.
+   *
+   * @param header an email header
+   * @returna reference to this, so the API can be used fluently
+   */
+  public DKIMSignOptions addCopiedHeader(String header) {
+    if (this.copiedHeaders == null) {
+      this.copiedHeaders = new ArrayList<>();
+    }
+    if (!this.copiedHeaders.contains(header)) {
+      this.copiedHeaders.add(header);
+    }
+    return this;
+  }
+
+  private List<Object> getList() {
+    return Arrays.asList(privateKey, privateKeyPath, signAlgo, signedHeaders, sdid, selector, headerCanonic, bodyCanonic
+    , auid, bodyLimit, signatureTimestamp, expireTime, copiedHeaders);
+  }
+
+  /*
+   * (non-Javadoc)
+   *
+   * @see java.lang.Object#equals(java.lang.Object)
+   */
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof DKIMSignOptions)) {
+      return false;
+    }
+    final DKIMSignOptions ops = (DKIMSignOptions) o;
+    return getList().equals(ops.getList());
+  }
+
+  /*
+   * (non-Javadoc)
+   *
+   * @see java.lang.Object#hashCode()
+   */
+  @Override
+  public int hashCode() {
+    return getList().hashCode();
+  }
+
+}

--- a/src/main/java/io/vertx/ext/mail/MessageCanonic.java
+++ b/src/main/java/io/vertx/ext/mail/MessageCanonic.java
@@ -1,0 +1,41 @@
+/*
+ *  Copyright (c) 2011-2019 The original author or authors
+ *
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  and Apache License v2.0 which accompanies this distribution.
+ *
+ *       The Eclipse Public License is available at
+ *       http://www.eclipse.org/legal/epl-v10.html
+ *
+ *       The Apache License v2.0 is available at
+ *       http://www.opensource.org/licenses/apache2.0.php
+ *
+ *  You may elect to redistribute this code under either of these licenses.
+ */
+
+package io.vertx.ext.mail;
+
+import io.vertx.codegen.annotations.VertxGen;
+
+/**
+ *
+ * Message canonicalization for DKIM.
+ *
+ * @author <a href="mailto: aoingl@gmail.com">Lin Gao</a>
+ */
+@VertxGen
+public enum MessageCanonic {
+  SIMPLE, // simple
+  RELAXED; // relaxed
+
+  /**
+   * Gets the message canonicalization representation.
+   *
+   * @return the message canonicalization representation
+   */
+  public String canonic() {
+    return this.name().toLowerCase();
+  }
+
+}

--- a/src/main/java/io/vertx/ext/mail/impl/dkim/DKIMSigner.java
+++ b/src/main/java/io/vertx/ext/mail/impl/dkim/DKIMSigner.java
@@ -1,0 +1,487 @@
+/*
+ *  Copyright (c) 2011-2019 The original author or authors
+ *
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  and Apache License v2.0 which accompanies this distribution.
+ *
+ *       The Eclipse Public License is available at
+ *       http://www.eclipse.org/legal/epl-v10.html
+ *
+ *       The Apache License v2.0 is available at
+ *       http://www.opensource.org/licenses/apache2.0.php
+ *
+ *  You may elect to redistribute this code under either of these licenses.
+ */
+
+package io.vertx.ext.mail.impl.dkim;
+
+import io.vertx.codegen.annotations.Nullable;
+import io.vertx.core.*;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.impl.logging.Logger;
+import io.vertx.core.impl.logging.LoggerFactory;
+import io.vertx.core.streams.Pipe;
+import io.vertx.core.streams.ReadStream;
+import io.vertx.core.streams.WriteStream;
+import io.vertx.ext.mail.DKIMSignOptions;
+import io.vertx.ext.mail.MessageCanonic;
+import io.vertx.ext.mail.mailencoder.EncodedPart;
+import io.vertx.ext.mail.mailencoder.Utils;
+
+import java.security.*;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.util.*;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+/**
+ * DKIM Signature Singer to sign the email according to the configurations.
+ *
+ * Refer to: https://tools.ietf.org/html/rfc6376
+ *
+ * @author <a href="mailto: aoingl@gmail.com">Lin Gao</a>
+ */
+public class DKIMSigner {
+
+  public static final String DKIM_SIGNATURE_HEADER = "DKIM-Signature";
+
+  private static final Logger logger = LoggerFactory.getLogger(DKIMSigner.class);
+
+  private final DKIMSignOptions dkimSignOptions;
+  private final String signatureTemplate;
+  private final Signature signatureService;
+  private static final Pattern DELIMITER = Pattern.compile("\n");
+
+  /**
+   * The Constuctor of DKIMSigner.
+   *
+   * It validates the {@link DKIMSignOptions} which may throws IllegalStateException.
+   *
+   * It tries to initialize a {@link Signature} so that it can be reused on each sign.
+   *
+   * @param dkimSignOptions the {@link DKIMSignOptions} used to perform the DKIM Sign.
+   * @throws IllegalStateException the exception to throw on invalid configurations.
+   */
+  public DKIMSigner(DKIMSignOptions dkimSignOptions, final Vertx vertx) {
+    this.dkimSignOptions = dkimSignOptions;
+    validate(this.dkimSignOptions);
+    this.signatureTemplate = dkimSignatureTemplate();
+    try {
+      KeyFactory kf = KeyFactory.getInstance("RSA");
+      String secretKey = dkimSignOptions.getPrivateKey();
+      if (secretKey == null) {
+        // private key file should be small, read it directly.
+        secretKey = vertx.fileSystem().readFileBlocking(dkimSignOptions.getPrivateKeyPath()).toString();
+      }
+      final PKCS8EncodedKeySpec keyspec = new PKCS8EncodedKeySpec(Base64.getMimeDecoder().decode(secretKey));
+      final PrivateKey privateKey = kf.generatePrivate(keyspec);
+      signatureService = Signature.getInstance(dkimSignOptions.getSignAlgo().signatureAlgorithm());
+      signatureService.initSign(privateKey);
+    } catch (NoSuchAlgorithmException | InvalidKeyException | InvalidKeySpecException e) {
+      throw new IllegalStateException("Failed to init the Signature", e);
+    }
+  }
+
+  /**
+   * Validate whether the values are following the spec.
+   *
+   * @throws IllegalStateException on any specification violence.
+   */
+  private void validate(DKIMSignOptions ops) throws IllegalStateException {
+    // required fields check
+    checkRequiredFields(ops);
+    // check identity and sdid
+    final String auid = ops.getAuid();
+    if (auid != null) {
+      String sdid = ops.getSdid();
+      if (!auid.toLowerCase().endsWith("@" + sdid.toLowerCase())
+        && !auid.toLowerCase().endsWith("." + sdid.toLowerCase())) {
+        throw new IllegalStateException("Identity domain mismatch, expected is: [xx]@[xx.]sdid");
+      }
+    }
+
+    // check required signed header field: 'from'
+    if (ops.getSignedHeaders().stream().noneMatch(h -> h.equalsIgnoreCase("from"))) {
+      throw new IllegalStateException("From field must be selected to sign.");
+    }
+
+  }
+
+  private void checkRequiredFields(DKIMSignOptions ops) {
+    if (ops.getSignAlgo() == null) {
+      throw new IllegalStateException("Sign Algorithm is required: rsa-sha1 or rsa-sha256");
+    }
+    if (ops.getPrivateKey() == null && ops.getPrivateKeyPath() == null) {
+      throw new IllegalStateException("Either private key or private key file path must be specified to sign");
+    }
+    if (ops.getSignedHeaders() == null || ops.getSignedHeaders().isEmpty()) {
+      throw new IllegalStateException("Email header fields to sign must be set");
+    }
+    if (ops.getSdid() == null) {
+      throw new IllegalStateException("Singing Domain Identifier(SDID) must be specified");
+    }
+    if (ops.getSelector() == null) {
+      throw new IllegalStateException("The selector must be specified to be able to verify");
+    }
+  }
+
+  String dkimSignatureTemplate() {
+    final StringBuilder sb = new StringBuilder();
+    // version is always 1
+    sb.append("v=1; ");
+    // sign algorithm
+    sb.append("a=").append(this.dkimSignOptions.getSignAlgo().dkimAlgoName()).append("; ");
+    // optional message canonic
+    MessageCanonic bodyCanonic = this.dkimSignOptions.getBodyCanonic();
+    MessageCanonic headerCanonic = this.dkimSignOptions.getHeaderCanonic();
+    sb.append("c=").append(headerCanonic.canonic()).append("/").append(bodyCanonic.canonic()).append("; ");
+
+    // sdid
+    String sdid = dkimQuotedPrintable(this.dkimSignOptions.getSdid());
+    sb.append("d=").append(sdid).append("; ");
+    // optional auid
+    String auid = this.dkimSignOptions.getAuid();
+    if (auid != null) {
+      sb.append("i=").append(dkimQuotedPrintable(auid)).append("; ");
+    } else {
+      sb.append("i=").append("@").append(sdid).append("; ");
+    }
+    // selector
+    sb.append("s=").append(dkimQuotedPrintable(this.dkimSignOptions.getSelector())).append("; ");
+    // h=
+    String signHeadersString = String.join(":", this.dkimSignOptions.getSignedHeaders());
+    sb.append("h=").append(signHeadersString).append("; ");
+    // body limit
+    if (this.dkimSignOptions.getBodyLimit() > 0) {
+      sb.append("l=").append(this.dkimSignOptions.getBodyLimit()).append("; ");
+    }
+    // optional sign time
+    if (this.dkimSignOptions.isSignatureTimestamp() || this.dkimSignOptions.getExpireTime() > 0) {
+      long time = System.currentTimeMillis() / 1000; // in seconds
+      sb.append("t=").append(time).append("; ");
+      if (this.dkimSignOptions.getExpireTime() > 0) {
+        long expire = time + this.dkimSignOptions.getExpireTime();
+        sb.append("x=").append(expire).append("; ");
+      }
+    }
+    return sb.toString();
+  }
+
+  /**
+   * Perform the DKIM Signature sign action.
+   *
+   * @param context the Vert.x Context so that it can run the blocking code like calculating the body hash
+   * @param encodedMessage The Encoded Message to be ready to sent to the wire
+   * @return The Future with a result as the value of header: 'DKIM-Signature'
+   */
+  public Future<String> signEmail(Context context, EncodedPart encodedMessage) {
+    return bodyHashing(context, encodedMessage).map(bh -> {
+      if (logger.isDebugEnabled()) {
+        logger.debug("DKIM Body Hash: " + bh);
+      }
+      try {
+        final StringBuilder dkimTagListBuilder = dkimTagList(encodedMessage).append("bh=").append(bh).append("; b=");
+        String dkimSignHeaderCanonic = canonicHeader(DKIM_SIGNATURE_HEADER, dkimTagListBuilder.toString());
+        final String tobeSigned = headersToSign(encodedMessage).append(dkimSignHeaderCanonic).toString();
+        if (logger.isDebugEnabled()) {
+          logger.debug("To be signed DKIM header: " + tobeSigned);
+        }
+        String returnStr;
+        synchronized (signatureService) {
+          signatureService.update(tobeSigned.getBytes());
+          String sig = Base64.getEncoder().encodeToString(signatureService.sign());
+          returnStr = dkimTagListBuilder.append(sig).toString();
+        }
+        if (logger.isDebugEnabled()) {
+          logger.debug(DKIM_SIGNATURE_HEADER + ": " + returnStr);
+        }
+        return returnStr;
+      } catch (Exception e) {
+        throw new RuntimeException("Cannot sign email", e);
+      }
+    });
+  }
+
+  // the attachPart is a base64 encoded stream already when this method is called.
+  private void walkThroughAttachStream(MessageDigest md, ReadStream<Buffer> stream, AtomicInteger written, Promise<Void> promise) {
+    final Pipe<Buffer> pipe = stream.pipe();
+    Promise<Void> pipePromise = Promise.promise();
+    pipePromise.future().setHandler(pr -> {
+      pipe.close();
+      if (pr.succeeded()) {
+        promise.complete();
+      } else {
+        promise.fail(pr.cause());
+      }
+    });
+    pipe.to(new WriteStream<Buffer>() {
+      private AtomicBoolean ended = new AtomicBoolean(false);
+
+      @Override
+      public WriteStream<Buffer> exceptionHandler(Handler<Throwable> handler) {
+        return this;
+      }
+
+      @Override
+      public Future<Void> write(Buffer data) {
+        Promise<Void> promise = Promise.promise();
+        write(data, promise);
+        return promise.future();
+      }
+
+      @Override
+      public void write(Buffer data, Handler<AsyncResult<Void>> handler) {
+        if (!ended.get() && !digest(md, data.getBytes(), written)) {
+          // can be end now
+          ended.set(true);
+        }
+        if (handler != null) {
+          handler.handle(Future.succeededFuture());
+        }
+      }
+
+      @Override
+      public void end(Handler<AsyncResult<Void>> handler) {
+        ended.compareAndSet(false, true);
+        if (handler != null) {
+          handler.handle(Future.succeededFuture());
+        }
+      }
+
+      @Override
+      public WriteStream<Buffer> setWriteQueueMaxSize(int maxSize) {
+        return this;
+      }
+
+      @Override
+      public boolean writeQueueFull() {
+        return false;
+      }
+
+      @Override
+      public WriteStream<Buffer> drainHandler(@Nullable Handler<Void> handler) {
+        return this;
+      }
+    }, pipePromise);
+  }
+
+  private boolean digest(MessageDigest md, byte[] bytes, AtomicInteger written) {
+    if (this.dkimSignOptions.getBodyLimit() > 0) {
+      int left = this.dkimSignOptions.getBodyLimit() - written.get();
+      if (left > 0) {
+        int len = Math.min(left, bytes.length);
+        md.update(bytes, 0, len);
+        written.getAndAdd(len);
+      } else {
+        return false;
+      }
+    } else {
+      md.update(bytes);
+    }
+    return true;
+  }
+
+  private Future<Boolean> walkBoundaryStartAndHeadersFuture(MessageDigest md, String boundaryStart, EncodedPart part, AtomicInteger written) {
+    Promise<Boolean> promise = Promise.promise();
+    try {
+      StringBuilder sb = new StringBuilder();
+      sb.append(boundaryStart);
+      part.headers().entries().forEach(entry -> sb.append(entry.toString()).append("\r\n"));
+      sb.append("\r\n");
+      promise.complete(digest(md, sb.toString().getBytes(), written));
+    } catch (Exception e) {
+      promise.fail(e);
+    }
+    return promise.future();
+  }
+
+  private void walkThroughMultiPart(Context context, MessageDigest md, EncodedPart multiPart, int index,
+                                    AtomicInteger written, Promise<Void> promise) {
+    String boundaryStart = "--" + multiPart.boundary() + "\r\n";
+    String boundaryEnd = "--" + multiPart.boundary() + "--";
+    if (index < multiPart.parts().size()) {
+      EncodedPart part = multiPart.parts().get(index);
+
+      Promise<Void> nextPartPromise = Promise.promise();
+      nextPartPromise.future().setHandler(r -> {
+        if (r.succeeded()) {
+          walkThroughMultiPart(context, md, multiPart, index + 1, written, promise);
+        } else {
+          promise.fail(r.cause());
+        }
+      });
+      // boundary and header, then body
+      walkBoundaryStartAndHeadersFuture(md, boundaryStart, part, written).setHandler(r -> {
+        if (r.succeeded()) {
+          if (r.result()) {
+            if (part.parts() != null && part.parts().size() > 0) {
+              // part is a multipart as well
+              walkThroughMultiPart(context, md, part, 0, written, nextPartPromise);
+            } else {
+              // walk through part body
+              if (part.body() != null) {
+                String canonicBody = dkimMailBody(part.body());
+                digest(md, canonicBody.getBytes(), written);
+                nextPartPromise.complete();
+              } else {
+                ReadStream<Buffer> dkimAttachStream = part.dkimBodyStream(context);
+                if (dkimAttachStream != null) {
+                  walkThroughAttachStream(md, dkimAttachStream, written, nextPartPromise);
+                } else {
+                  nextPartPromise.fail("No data and stream found.");
+                }
+              }
+            }
+          } else {
+            promise.complete();
+          }
+        } else {
+          promise.fail(r.cause());
+        }
+      });
+    } else {
+      // after last part has been walked through
+      digest(md, (boundaryEnd + "\r\n").getBytes(), written);
+      promise.complete();
+    }
+  }
+
+  // https://tools.ietf.org/html/rfc6376#section-3.7
+  private Future<String> bodyHashing(Context context, EncodedPart encodedMessage) {
+    Promise<String> bodyHashPromise = Promise.promise();
+    try {
+      final MessageDigest md = MessageDigest.getInstance(dkimSignOptions.getSignAlgo().hashAlgorithm());
+      if (encodedMessage.parts() != null && encodedMessage.parts().size() > 0) {
+        Promise<Void> multiPartWalkThrough = Promise.promise();
+        multiPartWalkThrough.future().setHandler(r -> {
+          if (r.succeeded()) {
+            try {
+              // MD has been updated through reading the whole multipart message.
+              String bh = Base64.getEncoder().encodeToString(md.digest());
+              bodyHashPromise.complete(bh);
+            } catch (Exception e) {
+              bodyHashPromise.fail(e);
+            }
+          } else {
+            bodyHashPromise.fail(r.cause());
+          }
+        });
+        walkThroughMultiPart(context, md, encodedMessage, 0, new AtomicInteger(), multiPartWalkThrough);
+      } else {
+        String canonicBody = dkimMailBody(encodedMessage.body());
+        digest(md, canonicBody.getBytes(), new AtomicInteger());
+        String bh = Base64.getEncoder().encodeToString(md.digest());
+        bodyHashPromise.complete(bh);
+      }
+    } catch (Exception e) {
+      bodyHashPromise.fail(e);
+    }
+    return bodyHashPromise.future();
+  }
+
+  private StringBuilder headersToSign(EncodedPart encodedMessage) {
+    final StringBuilder signHeaders = new StringBuilder();
+    // keep the order in the list, see: https://tools.ietf.org/html/rfc6376#section-3.7
+    // multiple instances of one header name may be specified: https://tools.ietf.org/html/rfc6376#section-5.4.2
+    final Map<String, Integer> valueIdx = new HashMap<>();
+    // in the order of specified signed headers list
+    for (String header: dkimSignOptions.getSignedHeaders()) {
+      // this is case insensitive headers
+      List<String> values = encodedMessage.headers().getAll(header);
+      final int size = values.size();
+      if (size > 0) {
+        // ignore the non-existed headers
+        int idx = valueIdx.computeIfAbsent(header.toUpperCase(Locale.ENGLISH), s -> size - 1);
+        if (idx >= 0) {
+          signHeaders.append(canonicHeader(header, values.get(idx))).append("\r\n");
+          valueIdx.put(header.toUpperCase(Locale.ENGLISH), idx - 1);
+        }
+      }
+    }
+    return signHeaders;
+  }
+
+  /**
+   * Computes DKIM Signature Sign tag list.
+   *
+   * @param encodedMessage the encoded message which is ready to write to the wire
+   * @return the StringBuilder represents the tag list based on the specified {@link DKIMSignOptions}
+   */
+  private StringBuilder dkimTagList(EncodedPart encodedMessage) {
+    final StringBuilder dkimTagList = new StringBuilder(this.signatureTemplate);
+    // optional copied headers
+    if (dkimSignOptions.getCopiedHeaders() != null && dkimSignOptions.getCopiedHeaders().size() > 0) {
+      dkimTagList.append("z=").append(copiedHeaders(dkimSignOptions.getCopiedHeaders(), encodedMessage)).append("; ");
+    }
+    return dkimTagList;
+  }
+
+  private String copiedHeaders(List<String> headers, EncodedPart encodedMessage) {
+    return headers.stream().map(h -> {
+      String hValue = encodedMessage.headers().get(h);
+      if (hValue != null) {
+        return h + ":" + dkimQuotedPrintableCopiedHeader(hValue);
+      }
+      throw new RuntimeException("Unknown email header: " + h + " in copied headers.");
+    }).collect(Collectors.joining("|"));
+  }
+
+  // https://tools.ietf.org/html/rfc6376#section-2.11
+  private static String dkimQuotedPrintable(String str) {
+    String dkimStr = Utils.encodeQP(str);
+    dkimStr = dkimStr.replaceAll(";", "=3B");
+    dkimStr = dkimStr.replaceAll(" ", "=20");
+    return dkimStr;
+  }
+
+  // https://tools.ietf.org/html/rfc6376#page-25
+  private String dkimQuotedPrintableCopiedHeader(String value) {
+    return dkimQuotedPrintable(value).replaceAll("\\|", "=7C");
+  }
+
+  /**
+   * Do Email Header Canonicalization.
+   *
+   * https://tools.ietf.org/html/rfc6376#section-3.4.1
+   * https://tools.ietf.org/html/rfc6376#section-3.4.2
+   *
+   * @param emailHeaderName the email header name used for the canonicalization.
+   * @param emailHeaderValue the email header value for the canonicalization.
+   * @return the canonicalization email header in format of 'Name':'Value'.
+   */
+  String canonicHeader(String emailHeaderName, String emailHeaderValue) {
+    if (this.dkimSignOptions.getHeaderCanonic() == MessageCanonic.SIMPLE) {
+      return emailHeaderName + ": " + emailHeaderValue;
+    }
+    String headerName = emailHeaderName.trim().toLowerCase();
+    return headerName + ":" + canonicLine(emailHeaderValue, this.dkimSignOptions.getHeaderCanonic());
+  }
+
+  String dkimMailBody(String mailBody) {
+    Scanner scanner = new Scanner(mailBody).useDelimiter(DELIMITER);
+    StringBuilder sb = new StringBuilder();
+    while (scanner.hasNext()) {
+      sb.append(canonicBodyLine(scanner.nextLine()));
+      sb.append("\r\n");
+    }
+    return sb.toString().replaceFirst("[\r\n]*$", "\r\n");
+  }
+
+  // this is shared by header and body for each line's canonicalization.
+  private String canonicLine(String line, MessageCanonic canonic) {
+    if (MessageCanonic.RELAXED == canonic) {
+      line = line.replaceAll("[\r\n\t ]+", " ");
+      line = line.replaceAll("[\r\n\t ]+$", "");
+    }
+    return line;
+  }
+
+  String canonicBodyLine(String line) {
+    return canonicLine(line, this.dkimSignOptions.getBodyCanonic());
+  }
+
+}

--- a/src/main/java/io/vertx/ext/mail/mailencoder/AttachmentPart.java
+++ b/src/main/java/io/vertx/ext/mail/mailencoder/AttachmentPart.java
@@ -16,20 +16,33 @@
 
 package io.vertx.ext.mail.mailencoder;
 
+import io.vertx.codegen.annotations.Nullable;
+import io.vertx.core.*;
 import io.vertx.core.buffer.Buffer;
+import io.vertx.core.file.AsyncFile;
+import io.vertx.core.file.OpenOptions;
 import io.vertx.core.http.CaseInsensitiveHeaders;
-import io.vertx.core.logging.Logger;
-import io.vertx.core.logging.LoggerFactory;
+import io.vertx.core.impl.logging.Logger;
+import io.vertx.core.impl.logging.LoggerFactory;
 import io.vertx.core.streams.ReadStream;
 import io.vertx.ext.mail.MailAttachment;
+
+import java.io.File;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 class AttachmentPart extends EncodedPart {
 
   private static final Logger log = LoggerFactory.getLogger(AttachmentPart.class);
 
+  // Whether to cache the ReadStream into an AsyncFile when DKIM is enabled.
+  private static final boolean CACHE_IN_FILE = Boolean.getBoolean("vertx.mail.attachment.cache.file");
+
+  private String cachedFilePath;
+
   private final MailAttachment attachment;
 
-  public AttachmentPart(MailAttachment attachment) {
+  AttachmentPart(MailAttachment attachment) {
     this.attachment = attachment;
     if (this.attachment.getData() == null && this.attachment.getStream() == null) {
       throw new IllegalArgumentException("Either data or stream of the attachment cannot be null");
@@ -79,8 +92,21 @@ class AttachmentPart extends EncodedPart {
   }
 
   @Override
-  public ReadStream<Buffer> bodyStream() {
-    return this.attachment.getStream();
+  public synchronized ReadStream<Buffer> bodyStream(Context context) {
+    ReadStream<Buffer> attachStream = this.attachment.getStream();
+    if (attachStream == null) {
+      return null;
+    }
+    return new BodyReadStream(context, attachStream, false);
+  }
+
+  @Override
+  public synchronized ReadStream<Buffer> dkimBodyStream(Context context) {
+    ReadStream<Buffer> attachStream = this.attachment.getStream();
+    if (attachStream == null) {
+      return null;
+    }
+    return new BodyReadStream(context, attachStream, true);
   }
 
   @Override
@@ -89,6 +115,209 @@ class AttachmentPart extends EncodedPart {
       return attachment.getSize() < 0 ? 0 : (attachment.getSize() / 3) * 4;
     }
     return super.size();
+  }
+
+  // what we need: strings line by line with CRLF as line terminator
+  private class BodyReadStream implements ReadStream<Buffer> {
+
+    private final Context context;
+    private final ReadStream<Buffer> stream;
+    private Handler<Throwable> exceptionHandler;
+
+    private final boolean cacheInMemory;
+    private final Buffer cachedBuffer;
+
+    private final boolean cacheInFile;
+    private final String cachedFilePath;
+    private AsyncFile cachedFile;
+    private static final String cacheFilePrefix = "_vertx_mail_attach_";
+    private static final String cachFileSuffix = ".data";
+
+    // 57 / 3 * 4 = 76, plus CRLF is 78, which is the email line length limit.
+    // see: https://tools.ietf.org/html/rfc5322#section-2.1.1
+    private final int size = 57;
+    private Buffer streamBuffer;
+    private Handler<Buffer> handler;
+    private Handler<Void> endHandler;
+    private boolean caching;
+    private AtomicBoolean streamEnded = new AtomicBoolean();
+
+    private BodyReadStream(Context context, ReadStream<Buffer> stream, boolean tryReset) {
+      Objects.requireNonNull(stream, "ReadStream cannot be null");
+      this.stream = stream;
+      this.context = context;
+      this.streamBuffer = Buffer.buffer();
+      if (tryReset) {
+        // cache
+        if (CACHE_IN_FILE) {
+          cacheInFile = true;
+          cachedFilePath = context.owner().fileSystem().createTempFileBlocking(cacheFilePrefix, cachFileSuffix);
+          cacheInMemory = false;
+          cachedBuffer = null;
+        } else {
+          // cache in memory then
+          cacheInFile = false;
+          cachedFilePath = null;
+          cacheInMemory = true;
+          cachedBuffer = Buffer.buffer();
+        }
+      } else {
+        this.cacheInMemory = false;
+        this.cachedBuffer = null;
+        this.cacheInFile = false;
+        this.cachedFilePath = null;
+      }
+    }
+
+    @Override
+    public synchronized BodyReadStream exceptionHandler(Handler<Throwable> handler) {
+      if (handler != null) {
+        stream.exceptionHandler(handler);
+        this.exceptionHandler = handler;
+      }
+      return this;
+    }
+
+    @Override
+    public synchronized BodyReadStream handler(@Nullable Handler<Buffer> handler) {
+      if (handler == null) {
+        stream.handler(null);
+        return this;
+      }
+      this.handler = handler;
+      stream.handler(b -> {
+        if (streamEnded.get()) {
+          handleEventInContext(this.exceptionHandler, new IllegalStateException("Stream has been closed, no more reading."));
+          return;
+        }
+        Buffer buffer = streamBuffer.appendBuffer(b);
+        Buffer bufferToSent = Buffer.buffer();
+        int start = 0;
+        while(start + size < buffer.length()) {
+          final String theLine = Utils.base64(buffer.getBytes(start, start + size));
+          bufferToSent.appendBuffer(Buffer.buffer(theLine + "\r\n"));
+          start += size;
+        }
+        streamBuffer = buffer.getBuffer(start, buffer.length());
+        handleEventInContext(this.handler, bufferToSent);
+        if (cacheInMemory || cacheInFile) {
+          cacheBuffer(b).setHandler(r -> {
+            synchronized (BodyReadStream.this) {
+              caching = false;
+              if (r.failed()) {
+                handleEventInContext(this.exceptionHandler, r.cause());
+              }
+              checkEnd();
+            }
+          });
+        }
+      });
+      return this;
+    }
+
+    // when this method is called, either cacheInMemory or cacheInFile is true
+    private synchronized Future<Void> cacheBuffer(Buffer buffer) {
+      caching = true;
+      Promise<Void> promise = Promise.promise();
+      if (cacheInMemory) {
+        cachedBuffer.appendBuffer(buffer);
+        promise.complete();
+      } else {
+        if (cachedFile == null) {
+          context.owner().fileSystem().open(cachedFilePath, new OpenOptions().setAppend(true))
+            .setHandler(c -> context.runOnContext(h -> {
+              if (c.succeeded()) {
+                synchronized (BodyReadStream.this) {
+                  cachedFile = c.result();
+                  cachedFile.write(buffer, promise);
+                }
+              } else {
+                promise.fail(c.cause());
+              }
+            }));
+        } else {
+          cachedFile.write(buffer, promise);
+        }
+      }
+      return promise.future();
+    }
+
+    private synchronized void checkEnd() {
+      if (streamEnded.get() && !caching) {
+        if (cacheInFile) {
+          // cache in an AsyncFile
+          AttachmentPart.this.attachment.setStream(cachedFile);
+          AttachmentPart.this.cachedFilePath = cachedFilePath;
+          handleEventInContext(endHandler, null);
+        } else if (cacheInMemory) {
+          // next read will be the body in memory.
+          part = Utils.base64(cachedBuffer.getBytes());
+          handleEventInContext(endHandler, null);
+        } else {
+          // normal stream, may need to delete the cached file if the cachedFilePath is not null
+          if (AttachmentPart.this.cachedFilePath != null) {
+            String tmpPath = AttachmentPart.this.cachedFilePath;
+            AttachmentPart.this.cachedFilePath = null;
+            context.owner().fileSystem().delete(tmpPath).setHandler(deleteCacheFile -> {
+              if (deleteCacheFile.succeeded()) {
+                handleEventInContext(endHandler, null);
+              } else {
+                new File(tmpPath).deleteOnExit();
+                handleEventInContext(this.exceptionHandler, deleteCacheFile.cause());
+              }
+            });
+          } else {
+            handleEventInContext(endHandler, null);
+          }
+        }
+      }
+    }
+
+    @Override
+    public synchronized BodyReadStream pause() {
+      stream.pause();
+      return this;
+    }
+
+    @Override
+    public synchronized BodyReadStream resume() {
+      stream.resume();
+      return this;
+    }
+
+    @Override
+    public synchronized BodyReadStream fetch(long amount) {
+      stream.fetch(amount);
+      return this;
+    }
+
+    @Override
+    public synchronized BodyReadStream endHandler(@Nullable Handler<Void> endHandler) {
+      if (endHandler == null) {
+        stream.endHandler(null);
+        return this;
+      }
+      this.endHandler = endHandler;
+      stream.endHandler(v -> {
+        if (!streamEnded.compareAndSet(false, true)) {
+          return;
+        }
+        if (streamBuffer.length() > 0 && this.handler != null) {
+          String theLine = Utils.base64(streamBuffer.getBytes());
+          Buffer buffer = Buffer.buffer(theLine + "\r\n");
+          handleEventInContext(this.handler, buffer);
+        }
+        checkEnd();
+      });
+      return this;
+    }
+
+    private <T> void handleEventInContext(Handler<T> handler, T t) {
+      if (handler != null) {
+        context.runOnContext(h -> handler.handle(t));
+      }
+    }
+
   }
 
 }

--- a/src/main/java/io/vertx/ext/mail/mailencoder/EncodedPart.java
+++ b/src/main/java/io/vertx/ext/mail/mailencoder/EncodedPart.java
@@ -16,12 +16,18 @@
 
 package io.vertx.ext.mail.mailencoder;
 
+import io.vertx.core.Context;
 import io.vertx.core.MultiMap;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.streams.ReadStream;
 
 import java.util.List;
 
+/**
+ * This is implementation detail class. It is not intended to be used outside of this mail client.
+ *
+ * @author <a href="mailto: aoingl@gmail.com">Lin Gao</a>
+ */
 public abstract class EncodedPart {
   MultiMap headers;
   String part;
@@ -47,7 +53,11 @@ public abstract class EncodedPart {
     return asString().length();
   }
 
-  public ReadStream<Buffer> bodyStream() {
+  public ReadStream<Buffer> bodyStream(Context context) {
+    return null;
+  }
+
+  public ReadStream<Buffer> dkimBodyStream(Context context) {
     return null;
   }
 

--- a/src/main/java/io/vertx/ext/mail/mailencoder/Utils.java
+++ b/src/main/java/io/vertx/ext/mail/mailencoder/Utils.java
@@ -29,7 +29,7 @@ public class Utils {
   private Utils() {
   }
 
-  static String encodeQP(String text) {
+  public static String encodeQP(String text) {
     byte[] utf8 = text.getBytes(StandardCharsets.UTF_8);
     StringBuilder sb = new StringBuilder();
 

--- a/src/test/java/io/vertx/ext/mail/MailWithDKIMSignTest.java
+++ b/src/test/java/io/vertx/ext/mail/MailWithDKIMSignTest.java
@@ -1,0 +1,759 @@
+/*
+ *  Copyright (c) 2011-2019 The original author or authors
+ *
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  and Apache License v2.0 which accompanies this distribution.
+ *
+ *       The Eclipse Public License is available at
+ *       http://www.eclipse.org/legal/epl-v10.html
+ *
+ *       The Apache License v2.0 is available at
+ *       http://www.opensource.org/licenses/apache2.0.php
+ *
+ *  You may elect to redistribute this code under either of these licenses.
+ */
+
+package io.vertx.ext.mail;
+
+import io.vertx.codegen.annotations.Nullable;
+import io.vertx.core.Context;
+import io.vertx.core.Handler;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.file.OpenOptions;
+import io.vertx.core.streams.ReadStream;
+import io.vertx.core.streams.impl.InboundBuffer;
+import io.vertx.ext.mail.impl.dkim.DKIMSigner;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.apache.james.jdkim.DKIMVerifier;
+import org.apache.james.jdkim.MockPublicKeyRecordRetriever;
+import org.apache.james.jdkim.api.SignatureRecord;
+import org.apache.james.jdkim.impl.Message;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.mail.internet.MimeMultipart;
+import java.io.ByteArrayInputStream;
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static io.vertx.ext.mail.TestUtils.*;
+
+/**
+ * Test sending mails with DKIM enabled.
+ *
+ * @author <a href="mailto:aoingl@gmail.com">Lin Gao</a>
+ */
+@RunWith(VertxUnitRunner.class)
+@org.junit.FixMethodOrder()
+public class MailWithDKIMSignTest extends SMTPTestWiser {
+
+  private static final String privateKey = "MIICdgIBADANBgkqhkiG9w0BAQEFAASCAmAwggJcAgEAAoGBAKqSazYC8pj/JQmo\n" +
+    "2ep0m3Shs6WGyHarknUzRJxiHWIVl2CvvOz2aCo4QCFk7nHjJbSQigA/xRrQ+Mzg\n" +
+    "uNv4n/c+0MjMQscpyhrMYhza89jP3yMRjIEPJxiQzeMgGHTQifiBfB+2a8959YkB\n" +
+    "oOJZuoY0TOEyB+Lm3j000B4evsRdAgMBAAECgYAdSw38dZ8iJVdABG6ANExqSEbo\n" +
+    "22/b6XU6iXZ0AOmY6apYoXWpoFudPJHO6l2E04SrMNNyXYFFLLQ9wy4cIOOfs5yB\n" +
+    "bdZ17tvOqSWT7nsCcuHpUvF89JNXnQvV2xwS6npp/tIuehMfxOxPLdN87Nge7BEy\n" +
+    "6DCSW7U72pX9zjl1BQJBANv56R9X+XLWjW6n4s0tZ271XVYI4DlRxQHYHP3B7eLm\n" +
+    "4DJtoHk65WU3kfHUeBNy/9TmpC25Gw6WTDco+mOS8wsCQQDGgVPCqhNDUcZYMeOH\n" +
+    "X6hm+l8zBeTMF2udQbkl0dRdLFpbMtw3cg+WUjHg3AYv38P2ikSJZzgzdDyZzcxF\n" +
+    "Hcc3AkBXoBNm8upg/mpUW/gSdzWuk3rcnKiE7LenZmkWBDw4mHNSYyz7XaSnTx2J\n" +
+    "0XMLfFHAgyd/Ny85/lDZ4C7tn0nFAkEAkS2mz9lJa1PUZ05dZPWuGVqF47AszKNY\n" +
+    "XlPiEGntEhPNJaQF8TsncT4+IoFouPzDun0XcRKfxOn/JFGiUu5bcwJAGbai+kPl\n" +
+    "AoyfGLxOLu40IMNOHKhHOq8cm3dOC+HpQYpx96JGaQPY4kl3fos6e43DGp9vyOxv\n" +
+    "VMj5fan+wzHLcw==";
+
+  // the corresponding public key for the private key above.
+  private static final String pubKeyStr =
+    "MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCqkms2AvKY/yUJqNnqdJt0obOl" +
+    "hsh2q5J1M0ScYh1iFZdgr7zs9mgqOEAhZO5x4yW0kIoAP8Ua0PjM4Ljb+J/3PtDI" +
+    "zELHKcoazGIc2vPYz98jEYyBDycYkM3jIBh00In4gXwftmvPefWJAaDiWbqGNEzh" +
+    "Mgfi5t49NNAeHr7EXQIDAQAB";
+
+  private static final String TEXT_BODY = "This is a Multiple Lines Text\r\n.Some lines start with one dot\n..Some" +
+    "lines start with 2 dots.\n Some line starts with \n \r\n\t\nspace and ends with space ";
+
+  private static final String HTML_BODY = "this is html text, \r\n <a href=\"http://vertx.io\">vertx.io</a>";
+
+  private final String IDENTITY = "f r;om@example.com";
+  private final DKIMSignOptions dkimOptionsBase = new DKIMSignOptions().setPrivateKey(privateKey)
+    .setAuid(IDENTITY).setSdid("example.com").setSelector("lgao").setSignAlgo(DKIMSignAlgorithm.RSA_SHA256);
+
+  private MailClient dkimMailClient(DKIMSignOptions dkimOps) {
+    return MailClient.createNonShared(vertx, configLogin().setEnableDKIM(true).addDKIMSignOption(dkimOps));
+  }
+
+  @Test
+  public void testMailSimpleSimplePlain(TestContext testContext) {
+    this.testContext = testContext;
+    MailMessage message = exampleMessage().setText(TEXT_BODY);
+    DKIMSignOptions dkimOps = new DKIMSignOptions(dkimOptionsBase)
+      .setHeaderCanonic(MessageCanonic.SIMPLE).setBodyCanonic(MessageCanonic.SIMPLE);
+    testSuccess(dkimMailClient(dkimOps), message, () -> {
+      testContext.assertEquals(TEXT_BODY + "\n", TestUtils.conv2nl(TestUtils.inputStreamToString(wiser.getMessages().get(0).getMimeMessage().getInputStream())));
+      testDKIMSign(dkimOps, testContext);
+    });
+  }
+
+  @Test
+  public void testMailSimpleRelaxedPlain(TestContext testContext) {
+    this.testContext = testContext;
+    MailMessage message = exampleMessage().setText(TEXT_BODY);
+    DKIMSignOptions dkimOps = new DKIMSignOptions(dkimOptionsBase)
+      .setHeaderCanonic(MessageCanonic.SIMPLE).setBodyCanonic(MessageCanonic.RELAXED);
+    testSuccess(dkimMailClient(dkimOps), message, () -> {
+      testContext.assertEquals(TEXT_BODY + "\n", TestUtils.conv2nl(TestUtils.inputStreamToString(wiser.getMessages().get(0).getMimeMessage().getInputStream())));
+      testDKIMSign(dkimOps, testContext);
+    });
+  }
+
+  @Test
+  public void testMailRelaxedRelaxedPlain(TestContext testContext) {
+    this.testContext = testContext;
+    MailMessage message = exampleMessage().setText(TEXT_BODY);
+    DKIMSignOptions dkimOps = new DKIMSignOptions(dkimOptionsBase)
+      .setHeaderCanonic(MessageCanonic.RELAXED).setBodyCanonic(MessageCanonic.RELAXED);
+    testSuccess(dkimMailClient(dkimOps), message, () -> {
+      testContext.assertEquals(TEXT_BODY + "\n", TestUtils.conv2nl(TestUtils.inputStreamToString(wiser.getMessages().get(0).getMimeMessage().getInputStream())));
+      testDKIMSign(dkimOps, testContext);
+    });
+  }
+
+  @Test
+  public void testMailSimpleSimpleMultiHeaderInstances(TestContext testContext) {
+    this.testContext = testContext;
+    List<String> signedHeaders = Stream.of("From", "Reply-to", "Subject", "To", "Received", "Received").collect(Collectors.toList());
+    MailMessage message = exampleMessage().setText(TEXT_BODY).addHeader("Received", "by 2002:ab3:7755:0:0:0:0:0 with SMTP id z21csp2085702lti")
+      .addHeader("Received", "by 2002:a05:620a:147c:: with SMTP id j28mr519391qkl.13.1575424987504");
+    DKIMSignOptions dkimOps = new DKIMSignOptions(dkimOptionsBase).setSignedHeaders(signedHeaders)
+      .setHeaderCanonic(MessageCanonic.SIMPLE).setBodyCanonic(MessageCanonic.SIMPLE);
+    testSuccess(dkimMailClient(dkimOps), message, () -> {
+      testContext.assertEquals(TEXT_BODY + "\n", TestUtils.conv2nl(TestUtils.inputStreamToString(wiser.getMessages().get(0).getMimeMessage().getInputStream())));
+      testDKIMSign(dkimOps, signedHeaders, testContext);
+    });
+  }
+
+  @Test
+  public void testMailSimpleRelaxedMultiHeaderInstances(TestContext testContext) {
+    this.testContext = testContext;
+    List<String> signedHeaders = Stream.of("From", "Reply-to", "Subject", "To", "Received", "Received").collect(Collectors.toList());
+    MailMessage message = exampleMessage().setText(TEXT_BODY).addHeader("Received", "by 2002:ab3:7755:0:0:0:0:0 with SMTP id z21csp2085702lti")
+      .addHeader("Received", "by 2002:a05:620a:147c:: with SMTP id j28mr519391qkl.13.1575424987504")
+      .addHeader("Received", "by 2005:a15:725a:579c:: with SMTP id j28mR876591qkl.13.1575473987504");
+    DKIMSignOptions dkimOps = new DKIMSignOptions(dkimOptionsBase).setSignedHeaders(signedHeaders)
+      .setHeaderCanonic(MessageCanonic.SIMPLE).setBodyCanonic(MessageCanonic.RELAXED);
+    testSuccess(dkimMailClient(dkimOps), message, () -> {
+      testContext.assertEquals(TEXT_BODY + "\n", TestUtils.conv2nl(TestUtils.inputStreamToString(wiser.getMessages().get(0).getMimeMessage().getInputStream())));
+      testDKIMSign(dkimOps, signedHeaders, testContext);
+    });
+  }
+
+  @Test
+  public void testMailRelaxedSimpleMultiHeaderInstances(TestContext testContext) {
+    this.testContext = testContext;
+    List<String> signedHeaders = Stream.of("From", "Reply-to", "Subject", "To", "Received", "Received").collect(Collectors.toList());
+    MailMessage message = exampleMessage().setText(TEXT_BODY).addHeader("Received", "by 2002:ab3:7755:0:0:0:0:0 with SMTP id z21csp2085702lti")
+      .addHeader("Received", "by 2002:a05:620a:147c:: with SMTP id j28mr519391qkl.13.1575424987504");
+    DKIMSignOptions dkimOps = new DKIMSignOptions(dkimOptionsBase).setSignedHeaders(signedHeaders)
+      .setHeaderCanonic(MessageCanonic.RELAXED).setBodyCanonic(MessageCanonic.SIMPLE);
+    testSuccess(dkimMailClient(dkimOps), message, () -> {
+      testContext.assertEquals(TEXT_BODY + "\n", TestUtils.conv2nl(TestUtils.inputStreamToString(wiser.getMessages().get(0).getMimeMessage().getInputStream())));
+      testDKIMSign(dkimOps, signedHeaders, testContext);
+    });
+  }
+
+  @Test
+  public void testMailRelaxedRelaxedMultiHeaderInstances(TestContext testContext) {
+    this.testContext = testContext;
+    List<String> signedHeaders = Stream.of("From", "Reply-to", "Subject", "To", "Received", "Received").collect(Collectors.toList());
+    MailMessage message = exampleMessage().setText(TEXT_BODY)
+      .addHeader("Received", "by 2002:ab3:7755:0:0:0:0:0 with SMTP id z21csp2085702lti")
+      .addHeader("Received", "by 2002:a05:620a:147c:: with SMTP id j28mr519391qkl.13.1575424987504");
+    DKIMSignOptions dkimOps = new DKIMSignOptions(dkimOptionsBase).setSignedHeaders(signedHeaders)
+      .setHeaderCanonic(MessageCanonic.RELAXED).setBodyCanonic(MessageCanonic.RELAXED);
+    testSuccess(dkimMailClient(dkimOps), message, () -> {
+      testContext.assertEquals(TEXT_BODY + "\n", TestUtils.conv2nl(TestUtils.inputStreamToString(wiser.getMessages().get(0).getMimeMessage().getInputStream())));
+      testDKIMSign(dkimOps, signedHeaders, testContext);
+    });
+  }
+
+  @Test
+  public void testMailRelaxedRelaxedPlainWithLimit(TestContext testContext) {
+    this.testContext = testContext;
+    MailMessage message = exampleMessage().setText(TEXT_BODY);
+    DKIMSignOptions dkimOps = new DKIMSignOptions(dkimOptionsBase).setBodyLimit(100)
+      .setHeaderCanonic(MessageCanonic.RELAXED).setBodyCanonic(MessageCanonic.RELAXED);
+    testSuccess(dkimMailClient(dkimOps), message, () -> {
+      testContext.assertEquals(TEXT_BODY + "\n", TestUtils.conv2nl(TestUtils.inputStreamToString(wiser.getMessages().get(0).getMimeMessage().getInputStream())));
+      testDKIMSign(dkimOps, testContext);
+    });
+  }
+
+  @Test
+  public void testMailRelaxedSimplePlainWithLimit(TestContext testContext) {
+    this.testContext = testContext;
+    MailMessage message = exampleMessage().setText(TEXT_BODY);
+    DKIMSignOptions dkimOps = new DKIMSignOptions(dkimOptionsBase).setBodyLimit(20)
+      .setHeaderCanonic(MessageCanonic.RELAXED).setBodyCanonic(MessageCanonic.SIMPLE);
+    testSuccess(dkimMailClient(dkimOps), message, () -> {
+      testContext.assertEquals(TEXT_BODY + "\n", TestUtils.conv2nl(TestUtils.inputStreamToString(wiser.getMessages().get(0).getMimeMessage().getInputStream())));
+      testDKIMSign(dkimOps, testContext);
+    });
+  }
+
+  @Test
+  public void testMailRelaxedSimplePlainWithLargeLimit(TestContext testContext) {
+    this.testContext = testContext;
+    MailMessage message = exampleMessage().setText(TEXT_BODY);
+    DKIMSignOptions dkimOps = new DKIMSignOptions(dkimOptionsBase).setBodyLimit(Integer.MAX_VALUE)
+      .setHeaderCanonic(MessageCanonic.RELAXED).setBodyCanonic(MessageCanonic.SIMPLE);
+    testSuccess(dkimMailClient(dkimOps), message, () -> {
+      testContext.assertEquals(TEXT_BODY + "\n", TestUtils.conv2nl(TestUtils.inputStreamToString(wiser.getMessages().get(0).getMimeMessage().getInputStream())));
+      testDKIMSign(dkimOps, testContext);
+    });
+  }
+
+  @Test
+  public void testMailRelaxedSimplePlain(TestContext testContext) {
+    this.testContext = testContext;
+    MailMessage message = exampleMessage().setText(TEXT_BODY);
+    DKIMSignOptions dkimOps = new DKIMSignOptions(dkimOptionsBase)
+      .setHeaderCanonic(MessageCanonic.RELAXED).setBodyCanonic(MessageCanonic.SIMPLE);
+    testSuccess(dkimMailClient(dkimOps), message, () -> {
+      testContext.assertEquals(TEXT_BODY + "\n", TestUtils.conv2nl(TestUtils.inputStreamToString(wiser.getMessages().get(0).getMimeMessage().getInputStream())));
+      testDKIMSign(dkimOps, testContext);
+    });
+  }
+
+  @Test
+  public void testMailSimpleSimplePlainFullOptions(TestContext testContext) {
+    this.testContext = testContext;
+    MailMessage message = exampleMessage().setText(TEXT_BODY);
+    DKIMSignOptions dkimOps = new DKIMSignOptions(dkimOptionsBase).setExpireTime(2000)
+      .setCopiedHeaders(Stream.of("From", "To").collect(Collectors.toList()))
+      .setHeaderCanonic(MessageCanonic.SIMPLE).setBodyCanonic(MessageCanonic.SIMPLE);
+    testSuccess(dkimMailClient(dkimOps), message, () -> {
+      testContext.assertEquals(TEXT_BODY + "\n", TestUtils.conv2nl(TestUtils.inputStreamToString(wiser.getMessages().get(0).getMimeMessage().getInputStream())));
+      testDKIMSign(dkimOps, testContext);
+    });
+  }
+
+  @Test
+  public void testMailSPlainNonExistedCopiedHeaders(TestContext testContext) {
+    this.testContext = testContext;
+    MailMessage message = exampleMessage().setText(TEXT_BODY);
+    DKIMSignOptions dkimOps = new DKIMSignOptions(dkimOptionsBase).setExpireTime(2000)
+      .setCopiedHeaders(Stream.of("From", "Not-Existed-Header").collect(Collectors.toList()))
+      .setHeaderCanonic(MessageCanonic.SIMPLE).setBodyCanonic(MessageCanonic.SIMPLE);
+    testException(dkimMailClient(dkimOps), message, RuntimeException.class);
+  }
+
+  @Test
+  public void testMailSimpleSimpleAttachment(TestContext testContext) {
+    this.testContext = testContext;
+    Buffer img = vertx.fileSystem().readFileBlocking("logo-white-big.png");
+    testContext.assertTrue(img.length() > 0);
+    MailAttachment attachment = MailAttachment.create().setName("logo-white-big.png").setData(img);
+    MailMessage message = exampleMessage().setText(TEXT_BODY).setAttachment(attachment);
+
+    DKIMSignOptions dkimOps = new DKIMSignOptions(dkimOptionsBase)
+      .setHeaderCanonic(MessageCanonic.SIMPLE).setBodyCanonic(MessageCanonic.SIMPLE);
+    testSuccess(dkimMailClient(dkimOps), message, () -> {
+      final MimeMultipart multiPart = (MimeMultipart)wiser.getMessages().get(0).getMimeMessage().getContent();
+      testContext.assertEquals(2, multiPart.getCount());
+      testContext.assertEquals(TEXT_BODY, conv2nl(inputStreamToString(multiPart.getBodyPart(0).getInputStream())));
+      testContext.assertTrue(Arrays.equals(img.getBytes(), inputStreamToBytes(multiPart.getBodyPart(1).getInputStream())));
+      testDKIMSign(dkimOps, testContext);
+    });
+  }
+
+  @Test
+  public void testMailSimpleRelaxedAttachment(TestContext testContext) {
+    this.testContext = testContext;
+    Buffer img = vertx.fileSystem().readFileBlocking("logo-white-big.png");
+    testContext.assertTrue(img.length() > 0);
+    MailAttachment attachment = MailAttachment.create().setName("logo-white-big.png").setData(img);
+    MailMessage message = exampleMessage().setText(TEXT_BODY).setAttachment(attachment);
+
+    DKIMSignOptions dkimOps = new DKIMSignOptions(dkimOptionsBase)
+      .setHeaderCanonic(MessageCanonic.SIMPLE).setBodyCanonic(MessageCanonic.RELAXED);
+    testSuccess(dkimMailClient(dkimOps), message, () -> {
+      final MimeMultipart multiPart = (MimeMultipart)wiser.getMessages().get(0).getMimeMessage().getContent();
+      testContext.assertEquals(2, multiPart.getCount());
+      testContext.assertEquals(TEXT_BODY, conv2nl(inputStreamToString(multiPart.getBodyPart(0).getInputStream())));
+      testContext.assertTrue(Arrays.equals(img.getBytes(), inputStreamToBytes(multiPart.getBodyPart(1).getInputStream())));
+      testDKIMSign(dkimOps, testContext);
+    });
+  }
+
+  @Test
+  public void testMailRelaxedSimpleAttachment(TestContext testContext) {
+    this.testContext = testContext;
+    Buffer img = vertx.fileSystem().readFileBlocking("logo-white-big.png");
+    testContext.assertTrue(img.length() > 0);
+    MailAttachment attachment = MailAttachment.create().setName("logo-white-big.png").setData(img);
+    MailMessage message = exampleMessage().setText(TEXT_BODY).setAttachment(attachment);
+
+    DKIMSignOptions dkimOps = new DKIMSignOptions(dkimOptionsBase)
+      .setHeaderCanonic(MessageCanonic.RELAXED).setBodyCanonic(MessageCanonic.SIMPLE);
+    testSuccess(dkimMailClient(dkimOps), message, () -> {
+      final MimeMultipart multiPart = (MimeMultipart)wiser.getMessages().get(0).getMimeMessage().getContent();
+      testContext.assertEquals(2, multiPart.getCount());
+      testContext.assertEquals(TEXT_BODY, conv2nl(inputStreamToString(multiPart.getBodyPart(0).getInputStream())));
+      testContext.assertTrue(Arrays.equals(img.getBytes(), inputStreamToBytes(multiPart.getBodyPart(1).getInputStream())));
+      testDKIMSign(dkimOps, testContext);
+    });
+  }
+
+  @Test
+  public void testMailRelaxedRelaxedAttachment(TestContext testContext) {
+    this.testContext = testContext;
+    Buffer img = vertx.fileSystem().readFileBlocking("logo-white-big.png");
+    testContext.assertTrue(img.length() > 0);
+    MailAttachment attachment = MailAttachment.create().setName("logo-white-big.png").setData(img);
+    MailMessage message = exampleMessage().setText(TEXT_BODY).setAttachment(attachment);
+
+    DKIMSignOptions dkimOps = new DKIMSignOptions(dkimOptionsBase)
+      .setHeaderCanonic(MessageCanonic.RELAXED).setBodyCanonic(MessageCanonic.RELAXED);
+    testSuccess(dkimMailClient(dkimOps), message, () -> {
+      final MimeMultipart multiPart = (MimeMultipart)wiser.getMessages().get(0).getMimeMessage().getContent();
+      testContext.assertEquals(2, multiPart.getCount());
+      testContext.assertEquals(TEXT_BODY, conv2nl(inputStreamToString(multiPart.getBodyPart(0).getInputStream())));
+      testContext.assertTrue(Arrays.equals(img.getBytes(), inputStreamToBytes(multiPart.getBodyPart(1).getInputStream())));
+      testDKIMSign(dkimOps, testContext);
+    });
+  }
+
+  @Test
+  public void testMailRelaxedRelaxedHtmlWithAttachment(TestContext testContext) {
+    this.testContext = testContext;
+    Buffer img = vertx.fileSystem().readFileBlocking("logo-white-big.png");
+    testContext.assertTrue(img.length() > 0);
+    MailAttachment attachment = MailAttachment.create().setName("logo-white-big.png").setData(img);
+    MailAttachment inLineAttachment = MailAttachment.create().setName("logo-inline").setData(img);
+    MailMessage message = exampleMessage()
+      .setText(TEXT_BODY)
+      .setHtml(HTML_BODY)
+      .setInlineAttachment(inLineAttachment)
+      .setAttachment(attachment);
+
+    DKIMSignOptions dkimOps = new DKIMSignOptions(dkimOptionsBase)
+      .setHeaderCanonic(MessageCanonic.RELAXED).setBodyCanonic(MessageCanonic.RELAXED);
+    testSuccess(dkimMailClient(dkimOps), message, () -> {
+
+      // 1. alternative multi part
+      //    1.1: text part
+      //    1.2: html multi part with inline attachment
+      //       1.2.1: html body part
+      //       1.2.2: inline attachment
+      // 2. attachment part
+      final MimeMultipart multiPart = (MimeMultipart)wiser.getMessages().get(0).getMimeMessage().getContent();
+      testContext.assertEquals(2, multiPart.getCount());
+      MimeMultipart alternative = (MimeMultipart)multiPart.getBodyPart(0).getContent();
+      testContext.assertEquals(2, alternative.getCount());
+      testContext.assertEquals(TEXT_BODY, conv2nl(inputStreamToString(alternative.getBodyPart(0).getInputStream())));
+      MimeMultipart htmlPart = (MimeMultipart)alternative.getBodyPart(1).getContent();
+      testContext.assertEquals(2, htmlPart.getCount());
+      testContext.assertEquals(HTML_BODY, conv2nl(inputStreamToString(htmlPart.getBodyPart(0).getInputStream())));
+      testContext.assertTrue(Arrays.equals(img.getBytes(), inputStreamToBytes(htmlPart.getBodyPart(1).getInputStream())));
+
+      testContext.assertTrue(Arrays.equals(img.getBytes(), inputStreamToBytes(multiPart.getBodyPart(1).getInputStream())));
+
+      testDKIMSign(dkimOps, testContext);
+    });
+  }
+
+  @Test
+  public void testMailRelaxedRelaxedHtmlWithAttachmentWithLimit(TestContext testContext) {
+    this.testContext = testContext;
+    Buffer img = vertx.fileSystem().readFileBlocking("logo-white-big.png");
+    testContext.assertTrue(img.length() > 0);
+    MailAttachment attachment = MailAttachment.create().setName("logo-white-big.png").setData(img);
+    MailAttachment inLineAttachment = MailAttachment.create().setName("logo-inline").setData(img);
+    MailMessage message = exampleMessage()
+      .setText(TEXT_BODY)
+      .setHtml(HTML_BODY)
+      .setInlineAttachment(inLineAttachment)
+      .setAttachment(attachment);
+
+    DKIMSignOptions dkimOps = new DKIMSignOptions(dkimOptionsBase).setBodyLimit(500)
+      .setHeaderCanonic(MessageCanonic.RELAXED).setBodyCanonic(MessageCanonic.RELAXED);
+    testSuccess(dkimMailClient(dkimOps), message, () -> {
+
+      // 1. alternative multi part
+      //    1.1: text part
+      //    1.2: html multi part with inline attachment
+      //       1.2.1: html body part
+      //       1.2.2: inline attachment
+      // 2. attachment part
+      final MimeMultipart multiPart = (MimeMultipart)wiser.getMessages().get(0).getMimeMessage().getContent();
+      testContext.assertEquals(2, multiPart.getCount());
+      MimeMultipart alternative = (MimeMultipart)multiPart.getBodyPart(0).getContent();
+      testContext.assertEquals(2, alternative.getCount());
+      testContext.assertEquals(TEXT_BODY, conv2nl(inputStreamToString(alternative.getBodyPart(0).getInputStream())));
+      MimeMultipart htmlPart = (MimeMultipart)alternative.getBodyPart(1).getContent();
+      testContext.assertEquals(2, htmlPart.getCount());
+      testContext.assertEquals(HTML_BODY, conv2nl(inputStreamToString(htmlPart.getBodyPart(0).getInputStream())));
+      testContext.assertTrue(Arrays.equals(img.getBytes(), inputStreamToBytes(htmlPart.getBodyPart(1).getInputStream())));
+
+      testContext.assertTrue(Arrays.equals(img.getBytes(), inputStreamToBytes(multiPart.getBodyPart(1).getInputStream())));
+
+      testDKIMSign(dkimOps, testContext);
+    });
+  }
+
+  @Test
+  public void testMailRelaxedRelaxedHtmlWithAttachmentStream(TestContext testContext) {
+    System.setProperty("vertx.mail.attachment.cache.file", "true");
+    this.testContext = testContext;
+    Buffer img = vertx.fileSystem().readFileBlocking("logo-white-big.png");
+    ReadStream<Buffer> stream = vertx.fileSystem().openBlocking("logo-white-big.png", new OpenOptions());
+    testContext.assertTrue(img.length() > 0);
+    MailAttachment attachment = MailAttachment.create().setName("logo-white-big.png").setSize(img.length()).setStream(stream);
+    MailAttachment inLineAttachment = MailAttachment.create().setName("logo-inline").setData(img);
+    MailMessage message = exampleMessage()
+      .setText(TEXT_BODY)
+      .setHtml(HTML_BODY)
+      .setInlineAttachment(inLineAttachment)
+      .setAttachment(attachment);
+
+    DKIMSignOptions dkimOps = new DKIMSignOptions(dkimOptionsBase)
+      .setHeaderCanonic(MessageCanonic.RELAXED).setBodyCanonic(MessageCanonic.RELAXED);
+    testSuccess(dkimMailClient(dkimOps), message, () -> {
+
+      // 1. alternative multi part
+      //    1.1: text part
+      //    1.2: html multi part with inline attachment
+      //       1.2.1: html body part
+      //       1.2.2: inline attachment
+      // 2. attachment part
+      final MimeMultipart multiPart = (MimeMultipart)wiser.getMessages().get(0).getMimeMessage().getContent();
+      testContext.assertEquals(2, multiPart.getCount());
+      MimeMultipart alternative = (MimeMultipart)multiPart.getBodyPart(0).getContent();
+      testContext.assertEquals(2, alternative.getCount());
+      testContext.assertEquals(TEXT_BODY, conv2nl(inputStreamToString(alternative.getBodyPart(0).getInputStream())));
+      MimeMultipart htmlPart = (MimeMultipart)alternative.getBodyPart(1).getContent();
+      testContext.assertEquals(2, htmlPart.getCount());
+      testContext.assertEquals(HTML_BODY, conv2nl(inputStreamToString(htmlPart.getBodyPart(0).getInputStream())));
+      testContext.assertTrue(Arrays.equals(img.getBytes(), inputStreamToBytes(htmlPart.getBodyPart(1).getInputStream())));
+
+      testContext.assertTrue(Arrays.equals(img.getBytes(), inputStreamToBytes(multiPart.getBodyPart(1).getInputStream())));
+
+      testDKIMSign(dkimOps, testContext);
+    });
+  }
+
+  @Test
+  public void testMailSimpleSimpleAttachmentStream(TestContext testContext) {
+    System.setProperty("vertx.mail.attachment.cache.file", "true");
+    this.testContext = testContext;
+    String path = "logo-white-big.png";
+    Buffer img = vertx.fileSystem().readFileBlocking(path);
+    ReadStream<Buffer> stream = vertx.fileSystem().openBlocking(path, new OpenOptions());
+    MailAttachment attachment = MailAttachment.create().setName(path).setStream(stream).setSize(img.length());
+    MailMessage message = exampleMessage().setText(TEXT_BODY).setAttachment(attachment);
+
+    DKIMSignOptions dkimOps = new DKIMSignOptions(dkimOptionsBase)
+      .setHeaderCanonic(MessageCanonic.SIMPLE).setBodyCanonic(MessageCanonic.SIMPLE);
+    testSuccess(dkimMailClient(dkimOps), message, () -> {
+      final MimeMultipart multiPart = (MimeMultipart)wiser.getMessages().get(0).getMimeMessage().getContent();
+      testContext.assertEquals(2, multiPart.getCount());
+      testContext.assertEquals(TEXT_BODY, conv2nl(inputStreamToString(multiPart.getBodyPart(0).getInputStream())));
+      testContext.assertTrue(Arrays.equals(img.getBytes(), inputStreamToBytes(multiPart.getBodyPart(1).getInputStream())));
+      testDKIMSign(dkimOps, testContext);
+    });
+  }
+
+  @Test
+  public void testMailSimpleRelaxedAttachmentStream(TestContext testContext) {
+    System.setProperty("vertx.mail.attachment.cache.file", "false");
+    this.testContext = testContext;
+    String path = "logo-white-big.png";
+    Buffer img = vertx.fileSystem().readFileBlocking(path);
+    ReadStream<Buffer> stream = vertx.fileSystem().openBlocking(path, new OpenOptions());
+    MailAttachment attachment = MailAttachment.create().setName("logo-white-big.png").setStream(stream).setSize(img.length());
+    MailMessage message = exampleMessage().setText(TEXT_BODY).setAttachment(attachment);
+
+    DKIMSignOptions dkimOps = new DKIMSignOptions(dkimOptionsBase)
+      .setHeaderCanonic(MessageCanonic.SIMPLE).setBodyCanonic(MessageCanonic.RELAXED);
+    testSuccess(dkimMailClient(dkimOps), message, () -> {
+      final MimeMultipart multiPart = (MimeMultipart)wiser.getMessages().get(0).getMimeMessage().getContent();
+      testContext.assertEquals(2, multiPart.getCount());
+      testContext.assertEquals(TEXT_BODY, conv2nl(inputStreamToString(multiPart.getBodyPart(0).getInputStream())));
+      testContext.assertTrue(Arrays.equals(img.getBytes(), inputStreamToBytes(multiPart.getBodyPart(1).getInputStream())));
+      testDKIMSign(dkimOps, testContext);
+    });
+  }
+
+  @Test
+  public void testMailRelaxedSimpleAttachmentStream(TestContext testContext) {
+    System.setProperty("vertx.mail.attachment.cache.file", "true");
+    this.testContext = testContext;
+    String path = "logo-white-big.png";
+    Buffer img = vertx.fileSystem().readFileBlocking(path);
+    ReadStream<Buffer> stream = vertx.fileSystem().openBlocking(path, new OpenOptions());
+    MailAttachment attachment = MailAttachment.create().setName("logo-white-big.png").setStream(stream).setSize(img.length());
+    MailMessage message = exampleMessage().setText(TEXT_BODY).setAttachment(attachment);
+
+    DKIMSignOptions dkimOps = new DKIMSignOptions(dkimOptionsBase)
+      .setHeaderCanonic(MessageCanonic.RELAXED).setBodyCanonic(MessageCanonic.SIMPLE);
+    testSuccess(dkimMailClient(dkimOps), message, () -> {
+      final MimeMultipart multiPart = (MimeMultipart)wiser.getMessages().get(0).getMimeMessage().getContent();
+      testContext.assertEquals(2, multiPart.getCount());
+      testContext.assertEquals(TEXT_BODY, conv2nl(inputStreamToString(multiPart.getBodyPart(0).getInputStream())));
+      testContext.assertTrue(Arrays.equals(img.getBytes(), inputStreamToBytes(multiPart.getBodyPart(1).getInputStream())));
+      testDKIMSign(dkimOps, testContext);
+    });
+  }
+
+  @Test
+  public void testMailRelaxedRelaxedAttachmentStream(TestContext testContext) {
+    System.setProperty("vertx.mail.attachment.cache.file", "false");
+    this.testContext = testContext;
+    String path = "logo-white-big.png";
+    Buffer img = vertx.fileSystem().readFileBlocking(path);
+    ReadStream<Buffer> stream = vertx.fileSystem().openBlocking(path, new OpenOptions());
+    MailAttachment attachment = MailAttachment.create().setName("logo-white-big.png").setStream(stream).setSize(img.length());
+    MailMessage message = exampleMessage().setText(TEXT_BODY).setAttachment(attachment);
+
+    DKIMSignOptions dkimOps = new DKIMSignOptions(dkimOptionsBase)
+      .setHeaderCanonic(MessageCanonic.RELAXED).setBodyCanonic(MessageCanonic.RELAXED);
+    testSuccess(dkimMailClient(dkimOps), message, () -> {
+      final MimeMultipart multiPart = (MimeMultipart)wiser.getMessages().get(0).getMimeMessage().getContent();
+      testContext.assertEquals(2, multiPart.getCount());
+      testContext.assertEquals(TEXT_BODY, conv2nl(inputStreamToString(multiPart.getBodyPart(0).getInputStream())));
+      testContext.assertTrue(Arrays.equals(img.getBytes(), inputStreamToBytes(multiPart.getBodyPart(1).getInputStream())));
+      testDKIMSign(dkimOps, testContext);
+    });
+  }
+
+  @Test
+  public void testMailRelaxedRelaxedAttachmentStreamWithLimit(TestContext testContext) {
+    System.setProperty("vertx.mail.attachment.cache.file", "true");
+    this.testContext = testContext;
+    String path = "logo-white-big.png";
+    Buffer img = vertx.fileSystem().readFileBlocking(path);
+    ReadStream<Buffer> stream = vertx.fileSystem().openBlocking(path, new OpenOptions());
+    MailAttachment attachment = MailAttachment.create().setName("logo-white-big.png").setStream(stream).setSize(img.length());
+    MailMessage message = exampleMessage().setText(TEXT_BODY).setAttachment(attachment);
+
+    DKIMSignOptions dkimOps = new DKIMSignOptions(dkimOptionsBase).setBodyLimit(100)
+      .setHeaderCanonic(MessageCanonic.RELAXED).setBodyCanonic(MessageCanonic.RELAXED);
+    testSuccess(dkimMailClient(dkimOps), message, () -> {
+      final MimeMultipart multiPart = (MimeMultipart)wiser.getMessages().get(0).getMimeMessage().getContent();
+      testContext.assertEquals(2, multiPart.getCount());
+      testContext.assertEquals(TEXT_BODY, conv2nl(inputStreamToString(multiPart.getBodyPart(0).getInputStream())));
+      testContext.assertTrue(Arrays.equals(img.getBytes(), inputStreamToBytes(multiPart.getBodyPart(1).getInputStream())));
+      testDKIMSign(dkimOps, testContext);
+    });
+  }
+
+  @Test
+  public void testMailRelaxedSimpleAttachmentStreamWithLimit(TestContext testContext) {
+    System.setProperty("vertx.mail.attachment.cache.file", "false");
+    this.testContext = testContext;
+    String path = "logo-white-big.png";
+    Buffer img = vertx.fileSystem().readFileBlocking(path);
+    ReadStream<Buffer> stream = vertx.fileSystem().openBlocking(path, new OpenOptions());
+    MailAttachment attachment = MailAttachment.create().setName("logo-white-big.png").setStream(stream).setSize(img.length());
+    MailMessage message = exampleMessage().setText(TEXT_BODY).setAttachment(attachment);
+
+    DKIMSignOptions dkimOps = new DKIMSignOptions(dkimOptionsBase).setBodyLimit(50)
+      .setHeaderCanonic(MessageCanonic.RELAXED).setBodyCanonic(MessageCanonic.SIMPLE);
+    testSuccess(dkimMailClient(dkimOps), message, () -> {
+      final MimeMultipart multiPart = (MimeMultipart)wiser.getMessages().get(0).getMimeMessage().getContent();
+      testContext.assertEquals(2, multiPart.getCount());
+      testContext.assertEquals(TEXT_BODY, conv2nl(inputStreamToString(multiPart.getBodyPart(0).getInputStream())));
+      testContext.assertTrue(Arrays.equals(img.getBytes(), inputStreamToBytes(multiPart.getBodyPart(1).getInputStream())));
+      testDKIMSign(dkimOps, testContext);
+    });
+  }
+
+  private Buffer fakeStreamData() {
+    String path = "logo-white-big.png";
+    return vertx.fileSystem().readFileBlocking(path);
+  }
+
+  private class FakeReadStream implements ReadStream<Buffer> {
+    private final InboundBuffer<Buffer> pending;
+    private Handler<Void> endHandler;
+
+    private FakeReadStream(Context context) {
+      this.pending = new InboundBuffer<Buffer>(context).emptyHandler(v -> checkEnd()).pause();
+      context.runOnContext(h -> this.pending.write(fakeStreamData()));
+    }
+
+    private void checkEnd() {
+      if (this.pending.isEmpty()) {
+        if (endHandler != null) {
+          endHandler.handle(null);
+        }
+      }
+    }
+
+    @Override
+    public synchronized ReadStream<Buffer> exceptionHandler(Handler<Throwable> handler) {
+      pending.exceptionHandler(handler);
+      return this;
+    }
+
+    @Override
+    public synchronized ReadStream<Buffer> handler(@Nullable Handler<Buffer> handler) {
+      pending.handler(handler);
+      return this;
+    }
+
+    @Override
+    public synchronized ReadStream<Buffer> pause() {
+      pending.pause();
+      return this;
+    }
+
+    @Override
+    public synchronized ReadStream<Buffer> resume() {
+      pending.resume();
+      return this;
+    }
+
+    @Override
+    public synchronized ReadStream<Buffer> fetch(long amount) {
+      pending.fetch(amount);
+      return this;
+    }
+
+    @Override
+    public synchronized ReadStream<Buffer> endHandler(@Nullable Handler<Void> endHandler) {
+      this.endHandler = endHandler;
+      return this;
+    }
+  }
+
+  @Test
+  public void testMailSimpleSimpleNonFileAttachmentStream(TestContext testContext) {
+    System.setProperty("vertx.mail.attachment.cache.file", "false");
+    this.testContext = testContext;
+    Buffer fakeData = fakeStreamData();
+    byte[] fakeDataBytes = fakeData.getBytes();
+    ReadStream<Buffer> fakeStream = new FakeReadStream(vertx.getOrCreateContext());
+    MailAttachment attachment = MailAttachment.create().setName("FakeStream")
+      .setStream(fakeStream)
+      .setSize(fakeDataBytes.length);
+    MailMessage message = exampleMessage().setText(TEXT_BODY).setAttachment(attachment);
+
+    DKIMSignOptions dkimOps = new DKIMSignOptions(dkimOptionsBase)
+      .setHeaderCanonic(MessageCanonic.SIMPLE).setBodyCanonic(MessageCanonic.SIMPLE);
+    testSuccess(dkimMailClient(dkimOps), message, () -> {
+      final MimeMultipart multiPart = (MimeMultipart)wiser.getMessages().get(0).getMimeMessage().getContent();
+      testContext.assertEquals(2, multiPart.getCount());
+      testContext.assertEquals(TEXT_BODY, conv2nl(inputStreamToString(multiPart.getBodyPart(0).getInputStream())));
+      testContext.assertTrue(Arrays.equals(fakeDataBytes, inputStreamToBytes(multiPart.getBodyPart(1).getInputStream())));
+      testDKIMSign(dkimOps, testContext);
+    });
+  }
+
+  @Test
+  public void testMailSimpleSimpleNonFileAttachmentStreamWithLimit(TestContext testContext) {
+    System.setProperty("vertx.mail.attachment.cache.file", "false");
+    this.testContext = testContext;
+    Buffer fakeData = fakeStreamData();
+    byte[] fakeDataBytes = fakeData.getBytes();
+    ReadStream<Buffer> fakeStream = new FakeReadStream(vertx.getOrCreateContext());
+    MailAttachment attachment = MailAttachment.create().setName("FakeStream")
+      .setStream(fakeStream)
+      .setSize(fakeDataBytes.length);
+    MailMessage message = exampleMessage().setText(TEXT_BODY).setAttachment(attachment);
+
+    DKIMSignOptions dkimOps = new DKIMSignOptions(dkimOptionsBase).setBodyLimit(50)
+      .setHeaderCanonic(MessageCanonic.SIMPLE).setBodyCanonic(MessageCanonic.SIMPLE);
+    testSuccess(dkimMailClient(dkimOps), message, () -> {
+      final MimeMultipart multiPart = (MimeMultipart)wiser.getMessages().get(0).getMimeMessage().getContent();
+      testContext.assertEquals(2, multiPart.getCount());
+      testContext.assertEquals(TEXT_BODY, conv2nl(inputStreamToString(multiPart.getBodyPart(0).getInputStream())));
+      testContext.assertTrue(Arrays.equals(fakeDataBytes, inputStreamToBytes(multiPart.getBodyPart(1).getInputStream())));
+      testDKIMSign(dkimOps, testContext);
+    });
+  }
+
+  @Test
+  public void testMailSimpleSimpleNonFileAttachmentStreamCacheInFile(TestContext testContext) {
+    System.setProperty("vertx.mail.attachment.cache.file", "true");
+    this.testContext = testContext;
+    Buffer fakeData = fakeStreamData();
+    byte[] fakeDataBytes = fakeData.getBytes();
+    ReadStream<Buffer> fakeStream = new FakeReadStream(vertx.getOrCreateContext());
+    MailAttachment attachment = MailAttachment.create().setName("FakeStream")
+      .setStream(fakeStream)
+      .setSize(fakeDataBytes.length);
+    MailMessage message = exampleMessage().setText(TEXT_BODY).setAttachment(attachment);
+
+    DKIMSignOptions dkimOps = new DKIMSignOptions(dkimOptionsBase)
+      .setHeaderCanonic(MessageCanonic.SIMPLE).setBodyCanonic(MessageCanonic.SIMPLE);
+    testSuccess(dkimMailClient(dkimOps), message, () -> {
+      final MimeMultipart multiPart = (MimeMultipart)wiser.getMessages().get(0).getMimeMessage().getContent();
+      testContext.assertEquals(2, multiPart.getCount());
+      testContext.assertEquals(TEXT_BODY, conv2nl(inputStreamToString(multiPart.getBodyPart(0).getInputStream())));
+      testContext.assertTrue(Arrays.equals(fakeDataBytes, inputStreamToBytes(multiPart.getBodyPart(1).getInputStream())));
+      testDKIMSign(dkimOps, testContext);
+    });
+  }
+
+  @Test
+  public void testMailSimpleSimpleNonFileAttachmentStreamCacheInFileWithLimit(TestContext testContext) {
+    System.setProperty("vertx.mail.attachment.cache.file", "true");
+    this.testContext = testContext;
+    Buffer fakeData = fakeStreamData();
+    byte[] fakeDataBytes = fakeData.getBytes();
+    ReadStream<Buffer> fakeStream = new FakeReadStream(vertx.getOrCreateContext());
+    MailAttachment attachment = MailAttachment.create().setName("FakeStream")
+      .setStream(fakeStream)
+      .setSize(fakeDataBytes.length);
+    MailMessage message = exampleMessage().setText(TEXT_BODY).setAttachment(attachment);
+
+    DKIMSignOptions dkimOps = new DKIMSignOptions(dkimOptionsBase).setBodyLimit(50)
+      .setHeaderCanonic(MessageCanonic.SIMPLE).setBodyCanonic(MessageCanonic.SIMPLE);
+    testSuccess(dkimMailClient(dkimOps), message, () -> {
+      final MimeMultipart multiPart = (MimeMultipart)wiser.getMessages().get(0).getMimeMessage().getContent();
+      testContext.assertEquals(2, multiPart.getCount());
+      testContext.assertEquals(TEXT_BODY, conv2nl(inputStreamToString(multiPart.getBodyPart(0).getInputStream())));
+      testContext.assertTrue(Arrays.equals(fakeDataBytes, inputStreamToBytes(multiPart.getBodyPart(1).getInputStream())));
+      testDKIMSign(dkimOps, testContext);
+    });
+  }
+
+  private void testDKIMSign(DKIMSignOptions dkimOps, TestContext ctx) throws Exception {
+    testDKIMSign(dkimOps, dkimOptionsBase.getSignedHeaders(), ctx);
+  }
+
+  private void testDKIMSign(DKIMSignOptions dkimOps, List<String> signHeaders, TestContext ctx) throws Exception {
+    Message jamesMessage = new Message(new ByteArrayInputStream(wiser.getMessages().get(0).getData()));
+    List<String> dkimHeaders = jamesMessage.getFields(DKIMSigner.DKIM_SIGNATURE_HEADER);
+    ctx.assertEquals(1, dkimHeaders.size());
+    String dkimSignTagsList = dkimHeaders.get(0);
+    ctx.assertNotNull(dkimSignTagsList);
+    Map<String, String> signTags = new HashMap<>();
+    Arrays.stream(dkimSignTagsList.substring(dkimSignTagsList.indexOf(":") + 1).split(";")).map(String::trim).forEach(part -> {
+      int idx = part.indexOf("=");
+      signTags.put(part.substring(0, idx), part.substring(idx + 1));
+    });
+    ctx.assertEquals("1", signTags.get("v"));
+    ctx.assertEquals(DKIMSignAlgorithm.RSA_SHA256.dkimAlgoName(), signTags.get("a"));
+    ctx.assertEquals(dkimOps.getHeaderCanonic().canonic() + "/" + dkimOps.getBodyCanonic().canonic(), signTags.get("c"));
+    ctx.assertEquals("example.com", signTags.get("d"));
+    ctx.assertEquals("lgao", signTags.get("s"));
+    ctx.assertEquals(String.join(":", signHeaders), signTags.get("h"));
+
+    MockPublicKeyRecordRetriever recordRetriever = new MockPublicKeyRecordRetriever();
+    recordRetriever.addRecord("lgao", "example.com", "v=DKIM1; k=rsa; p=" + pubKeyStr);
+    DKIMVerifier dkimVerifier = new DKIMVerifier(recordRetriever);
+    List<SignatureRecord> records = dkimVerifier.verify(jamesMessage, jamesMessage.getBodyInputStream());
+    SignatureRecord record = records.get(0);
+    ctx.assertNotNull(record);
+    ctx.assertEquals("lgao", record.getSelector());
+    ctx.assertEquals(IDENTITY, record.getIdentity());
+    ctx.assertEquals("example.com", record.getDToken());
+    ctx.assertEquals("sha-256", record.getHashAlgo());
+  }
+
+}

--- a/src/test/java/io/vertx/ext/mail/impl/dkim/DKIMSignerTest.java
+++ b/src/test/java/io/vertx/ext/mail/impl/dkim/DKIMSignerTest.java
@@ -1,0 +1,305 @@
+/*
+ *  Copyright (c) 2011-2019 The original author or authors
+ *
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  and Apache License v2.0 which accompanies this distribution.
+ *
+ *       The Eclipse Public License is available at
+ *       http://www.eclipse.org/legal/epl-v10.html
+ *
+ *       The Apache License v2.0 is available at
+ *       http://www.opensource.org/licenses/apache2.0.php
+ *
+ *  You may elect to redistribute this code under either of these licenses.
+ */
+
+package io.vertx.ext.mail.impl.dkim;
+
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.mail.DKIMSignAlgorithm;
+import io.vertx.ext.mail.DKIMSignOptions;
+import io.vertx.ext.mail.MessageCanonic;
+import org.junit.Test;
+
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.junit.Assert.*;
+
+/**
+ * Tests against DKIMSigner and it's configurations.
+ *
+ * @author <a href="mailto: aoingl@gmail.com">Lin Gao</a>
+ */
+public class DKIMSignerTest {
+
+  // a PKCS#8 format private key for testing
+  private final static String PRIVATE_KEY =
+    "MIICdgIBADANBgkqhkiG9w0BAQEFAASCAmAwggJcAgEAAoGBAKqSazYC8pj/JQmo\n" +
+      "2ep0m3Shs6WGyHarknUzRJxiHWIVl2CvvOz2aCo4QCFk7nHjJbSQigA/xRrQ+Mzg\n" +
+      "uNv4n/c+0MjMQscpyhrMYhza89jP3yMRjIEPJxiQzeMgGHTQifiBfB+2a8959YkB\n" +
+      "oOJZuoY0TOEyB+Lm3j000B4evsRdAgMBAAECgYAdSw38dZ8iJVdABG6ANExqSEbo\n" +
+      "22/b6XU6iXZ0AOmY6apYoXWpoFudPJHO6l2E04SrMNNyXYFFLLQ9wy4cIOOfs5yB\n" +
+      "bdZ17tvOqSWT7nsCcuHpUvF89JNXnQvV2xwS6npp/tIuehMfxOxPLdN87Nge7BEy\n" +
+      "6DCSW7U72pX9zjl1BQJBANv56R9X+XLWjW6n4s0tZ271XVYI4DlRxQHYHP3B7eLm\n" +
+      "4DJtoHk65WU3kfHUeBNy/9TmpC25Gw6WTDco+mOS8wsCQQDGgVPCqhNDUcZYMeOH\n" +
+      "X6hm+l8zBeTMF2udQbkl0dRdLFpbMtw3cg+WUjHg3AYv38P2ikSJZzgzdDyZzcxF\n" +
+      "Hcc3AkBXoBNm8upg/mpUW/gSdzWuk3rcnKiE7LenZmkWBDw4mHNSYyz7XaSnTx2J\n" +
+      "0XMLfFHAgyd/Ny85/lDZ4C7tn0nFAkEAkS2mz9lJa1PUZ05dZPWuGVqF47AszKNY\n" +
+      "XlPiEGntEhPNJaQF8TsncT4+IoFouPzDun0XcRKfxOn/JFGiUu5bcwJAGbai+kPl\n" +
+      "AoyfGLxOLu40IMNOHKhHOq8cm3dOC+HpQYpx96JGaQPY4kl3fos6e43DGp9vyOxv\n" +
+      "VMj5fan+wzHLcw==";
+
+  @Test
+  public void testDefaultConstructor() {
+    final DKIMSignOptions dkimOps = new DKIMSignOptions();
+    assertNotNull(dkimOps);
+
+    assertNull(dkimOps.getAuid());
+    assertNull(dkimOps.getCopiedHeaders());
+    assertNull(dkimOps.getSdid());
+    assertNull(dkimOps.getSelector());
+    assertFalse(dkimOps.isSignatureTimestamp());
+
+    assertTrue(dkimOps.getSignedHeaders().stream().anyMatch(h -> h.equalsIgnoreCase("from")));
+    assertEquals(DKIMSignAlgorithm.RSA_SHA256, dkimOps.getSignAlgo());
+    assertEquals(MessageCanonic.SIMPLE, dkimOps.getHeaderCanonic());
+    assertEquals(MessageCanonic.SIMPLE, dkimOps.getBodyCanonic());
+    assertEquals(-1, dkimOps.getBodyLimit());
+    assertEquals(-1, dkimOps.getExpireTime());
+
+    JsonObject json = dkimOps.toJson();
+    assertEquals(DKIMSignAlgorithm.RSA_SHA256, DKIMSignAlgorithm.valueOf(json.getString("signAlgo")));
+    assertEquals(MessageCanonic.SIMPLE.name(), json.getString("headerCanonic"));
+    assertEquals(MessageCanonic.SIMPLE.name(), json.getString("bodyCanonic"));
+  }
+
+  @Test
+  public void testConfigFull() {
+    final DKIMSignOptions dkimOps = new DKIMSignOptions();
+    assertNotNull(dkimOps);
+
+    dkimOps.setAuid("local-part@example.com");
+    dkimOps.setSdid("example.com");
+    dkimOps.setBodyCanonic(MessageCanonic.RELAXED);
+    dkimOps.setBodyLimit(5000);
+    dkimOps.setCopiedHeaders(Stream.of("From", "To").collect(Collectors.toList()));
+    dkimOps.setSelector("exampleUser");
+    dkimOps.setHeaderCanonic(MessageCanonic.SIMPLE);
+    dkimOps.setPrivateKey(PRIVATE_KEY);
+
+    assertEquals("local-part@example.com", dkimOps.getAuid());
+    assertEquals("example.com", dkimOps.getSdid());
+    assertEquals(MessageCanonic.RELAXED, dkimOps.getBodyCanonic());
+    assertEquals(5000, dkimOps.getBodyLimit());
+    assertArrayEquals(new String[]{"From", "To"}, dkimOps.getCopiedHeaders().toArray());
+    assertEquals("exampleUser", dkimOps.getSelector());
+    assertEquals(MessageCanonic.SIMPLE, dkimOps.getHeaderCanonic());
+
+    DKIMSigner dkimSigner = new DKIMSigner(dkimOps, null);
+    assertNotNull(dkimSigner);
+
+  }
+
+  @Test
+  public void testInvalidConfig() {
+    final DKIMSignOptions dkimOps = new DKIMSignOptions();
+
+    try {
+      new DKIMSigner(dkimOps, null);
+      fail("not here");
+    } catch (IllegalStateException e) {
+      assertEquals("Either private key or private key file path must be specified to sign", e.getMessage());
+    }
+
+    dkimOps.setPrivateKey(PRIVATE_KEY);
+    dkimOps.setSdid("example.com");
+    try {
+      new DKIMSigner(dkimOps, null);
+      fail("not here");
+    } catch (IllegalStateException e) {
+      assertEquals("The selector must be specified to be able to verify", e.getMessage());
+    }
+    dkimOps.setSelector("examUser");
+
+    dkimOps.setSdid("example.com");
+    dkimOps.setAuid("local-part@another.domain.com");
+    try {
+      new DKIMSigner(dkimOps, null);
+      fail("not here");
+    } catch (IllegalStateException e) {
+      assertEquals("Identity domain mismatch, expected is: [xx]@[xx.]sdid", e.getMessage());
+    }
+  }
+
+  private DKIMSignOptions dkimOps() {
+    final DKIMSignOptions dkimOps = new DKIMSignOptions();
+    dkimOps.setPrivateKey(PRIVATE_KEY);
+    dkimOps.setSelector("examUser");
+    dkimOps.setSdid("example.com");
+    dkimOps.setAuid("local-part@example.com");
+    return dkimOps;
+  }
+
+  @Test
+  public void testDKIMHeaderTemplate() {
+    DKIMSignOptions dkimOps = dkimOps();
+    DKIMSigner signer = new DKIMSigner(dkimOps, null);
+    String dkimTagsListTemplate = signer.dkimSignatureTemplate();
+    String expected = "v=1; a=rsa-sha256; c=simple/simple; d=example.com; " +
+      "i=local-part@example.com; s=examUser; h=From:Reply-to:Subject:Date:To:Cc:Content-Type:Message-ID; ";
+    assertEquals(expected, dkimTagsListTemplate);
+
+    dkimOps.setSelector("with space");
+    signer = new DKIMSigner(dkimOps, null);
+    dkimTagsListTemplate = signer.dkimSignatureTemplate();
+    expected = "v=1; a=rsa-sha256; c=simple/simple; d=example.com; " +
+      "i=local-part@example.com; s=with=20space; h=From:Reply-to:Subject:Date:To:Cc:Content-Type:Message-ID; ";
+    assertEquals(expected, dkimTagsListTemplate);
+
+    dkimOps.setAuid(null);
+    signer = new DKIMSigner(dkimOps, null);
+    dkimTagsListTemplate = signer.dkimSignatureTemplate();
+    expected = "v=1; a=rsa-sha256; c=simple/simple; d=example.com; " +
+      "i=@example.com; s=with=20space; h=From:Reply-to:Subject:Date:To:Cc:Content-Type:Message-ID; ";
+    assertEquals(expected, dkimTagsListTemplate);
+
+  }
+
+  @Test
+  public void testSimpleHeader() {
+    DKIMSignOptions dkimOps = dkimOps().setHeaderCanonic(MessageCanonic.SIMPLE);
+    DKIMSigner signer = new DKIMSigner(dkimOps, null);
+    // there will be possible to have \n in the header value, keep it as it is.
+    String name = "from";
+    String value = "user@example.com";
+    String canonicHeaderLine = signer.canonicHeader(name, value);
+    assertEquals("from: user@example.com", canonicHeaderLine);
+
+    name = "from ";
+    value = "user@example.com";
+    canonicHeaderLine = signer.canonicHeader(name, value);
+    assertEquals("from : user@example.com", canonicHeaderLine);
+
+    name = " from ";
+    value = " user@example.com ";
+    canonicHeaderLine = signer.canonicHeader(name, value);
+    assertEquals(" from :  user@example.com ", canonicHeaderLine);
+
+    name = " from ";
+    value = " user@example.com \n ";
+    canonicHeaderLine = signer.canonicHeader(name, value);
+    assertEquals(" from :  user@example.com \n ", canonicHeaderLine);
+  }
+
+  @Test
+  public void testRelaxedHeader() {
+    DKIMSignOptions dkimOps = dkimOps().setHeaderCanonic(MessageCanonic.RELAXED);
+    DKIMSigner signer = new DKIMSigner(dkimOps, null);
+    // there will be possible to have \n in the header value
+    String name = "From";
+    String value = "user@example.com";
+    String canonicHeaderLine = signer.canonicHeader(name, value);
+    assertEquals("from:user@example.com", canonicHeaderLine);
+
+    name = "From ";
+    value = "user@example.com";
+    canonicHeaderLine = signer.canonicHeader(name, value);
+    assertEquals("from:user@example.com", canonicHeaderLine);
+
+    name = " From";
+    value = "user@example.com\t ";
+    canonicHeaderLine = signer.canonicHeader(name, value);
+    assertEquals("from:user@example.com", canonicHeaderLine);
+
+    name = "From";
+    value = " user@example.com \n \t ";
+    canonicHeaderLine = signer.canonicHeader(name, value);
+    assertEquals("from: user@example.com", canonicHeaderLine);
+
+    name = "dummyHeader";
+    value = " dummyValue \r \r\n \t  test  ";
+    canonicHeaderLine = signer.canonicHeader(name, value);
+    assertEquals("dummyheader: dummyValue test", canonicHeaderLine);
+  }
+
+  @Test
+  public void testRelaxedBodyLine() {
+    DKIMSignOptions dkimOps = dkimOps().setBodyCanonic(MessageCanonic.RELAXED);
+    DKIMSigner signer = new DKIMSigner(dkimOps, null);
+    // there will be no \n in each line, so just test whitespaces
+    String line = "Line with trailing HTAB\t";
+    String cannonicLine = signer.canonicBodyLine(line);
+    assertEquals("Line with trailing HTAB", cannonicLine);
+
+    line = "Line with trailing HTAB and space \t ";
+    cannonicLine = signer.canonicBodyLine(line);
+    assertEquals("Line with trailing HTAB and space", cannonicLine);
+
+    line = "\tLine with leading HTAB";
+    cannonicLine = signer.canonicBodyLine(line);
+    assertEquals(" Line with leading HTAB", cannonicLine);
+
+    line = "\t Line with leading HTAB and space";
+    cannonicLine = signer.canonicBodyLine(line);
+    assertEquals(" Line with leading HTAB and space", cannonicLine);
+
+    line = "\t Line with leading and trailing HTAB and space \t ";
+    cannonicLine = signer.canonicBodyLine(line);
+    assertEquals(" Line with leading and trailing HTAB and space", cannonicLine);
+
+  }
+
+  @Test
+  public void testSimpleBodyCannonic() {
+    DKIMSignOptions dkimOps = dkimOps().setBodyCanonic(MessageCanonic.SIMPLE);
+    DKIMSigner signer = new DKIMSigner(dkimOps, null);
+
+    String body = "This is a Multiple Lines Text\n.Some lines start with one dot\n..Some" +
+      "lines start with 2 dots.\n";
+    String cannonicBody = signer.dkimMailBody(body);
+    assertEquals("This is a Multiple Lines Text\r\n.Some lines start with one dot\r\n..Some" +
+      "lines start with 2 dots.\r\n", cannonicBody);
+
+    body = "This is a Multiple Lines Text\n.Some lines start with one dot\n..Some" +
+      "lines start with 2 dots. \r\n\r\n\r\n\r\n\r\n";
+    cannonicBody = signer.dkimMailBody(body);
+    assertEquals("This is a Multiple Lines Text\r\n.Some lines start with one dot\r\n..Some" +
+      "lines start with 2 dots. \r\n", cannonicBody);
+
+    body = "This is a Multiple Lines Text\n.Some lines start with one dot\n..Some" +
+      "lines start with 2 dots.\n \r\n \t \r\n";
+    cannonicBody = signer.dkimMailBody(body);
+    assertEquals("This is a Multiple Lines Text\r\n.Some lines start with one dot\r\n..Some" +
+      "lines start with 2 dots.\r\n \r\n \t \r\n", cannonicBody);
+  }
+
+  @Test
+  public void testRelaxedBodyCannonic() {
+    DKIMSignOptions dkimOps = dkimOps().setBodyCanonic(MessageCanonic.RELAXED);
+    DKIMSigner signer = new DKIMSigner(dkimOps, null);
+
+    String body = "simple line";
+    String cannonicBody = signer.dkimMailBody(body);
+    assertEquals("simple line\r\n", cannonicBody);
+
+    body = "simple line ";
+    cannonicBody = signer.dkimMailBody(body);
+    assertEquals("simple line\r\n", cannonicBody);
+
+    body = " \tsimple line \t ";
+    cannonicBody = signer.dkimMailBody(body);
+    assertEquals(" simple line\r\n", cannonicBody);
+
+    body = " line \r\nnext \t line\r\n\r\n\r\n";
+    cannonicBody = signer.dkimMailBody(body);
+    assertEquals(" line\r\nnext line\r\n", cannonicBody);
+
+    body = " line \t\r\nnext \t line \t \r\n\r\n\r\n";
+    cannonicBody = signer.dkimMailBody(body);
+    assertEquals(" line\r\nnext line\r\n", cannonicBody);
+
+  }
+
+}


### PR DESCRIPTION
* Added DKIMSignOptions to specify options for DKIM signature
* Added james-jdkim to test scope for the signature verification tests
* Enable catch for Attachment's ReadStream in case DKIM is enabled

Signed-off-by: Lin Gao <aoingl@gmail.com>

Fixes: #102 

Feature RFC doc: https://github.com/gaol/vertx-mail-client/wiki/DKIM-Implementation

Summary of the PR:

* Added `DKIMSignOptions` to specify DKIM related configurations
* Added `enableDKIM` in MailConfig as well so that it can be disabled without losing configures.
   * I am open to have `DKIMSignOptions` only in `MailConfig` as well.
* Updated docs about how to use it

