### PR TITLE
[Issue-124] Try next authentication mechanism if current one failed

### DIFF
--- a/src/main/java/io/vertx/ext/mail/impl/SMTPStarter.java
+++ b/src/main/java/io/vertx/ext/mail/impl/SMTPStarter.java
@@ -21,8 +21,8 @@ import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.impl.logging.Logger;
 import io.vertx.core.impl.logging.LoggerFactory;
-import io.vertx.ext.auth.PRNG;
 import io.vertx.ext.mail.MailConfig;
+import io.vertx.ext.mail.impl.sasl.AuthOperationFactory;
 
 /**
  * this encapsulates open connection, initial dialogue and authentication
@@ -36,14 +36,14 @@ class SMTPStarter {
   private final SMTPConnection connection;
   private final String hostname;
   private final MailConfig config;
-  private final PRNG prng;
+  private final AuthOperationFactory authOperationFactory;
   private final Handler<AsyncResult<Void>> handler;
 
-  SMTPStarter(SMTPConnection connection, MailConfig config, String hostname, PRNG prng, Handler<AsyncResult<Void>> handler) {
+  SMTPStarter(SMTPConnection connection, MailConfig config, String hostname, AuthOperationFactory authOperationFactory, Handler<AsyncResult<Void>> handler) {
     this.connection = connection;
     this.hostname = hostname;
     this.config = config;
-    this.prng = prng;
+    this.authOperationFactory = authOperationFactory;
     this.handler = handler;
   }
 
@@ -59,7 +59,7 @@ class SMTPStarter {
 
   private void doAuthentication() {
     log.debug("SMTPAuthentication");
-    new SMTPAuthentication(connection, config, prng, v -> handler.handle(Future.succeededFuture(null)), this::handleError).start();
+    new SMTPAuthentication(connection, config, this.authOperationFactory, v -> handler.handle(Future.succeededFuture(null)), this::handleError).start();
   }
 
   private void handleError(Throwable throwable) {

--- a/src/main/java/io/vertx/ext/mail/impl/sasl/AuthXOAUTH2.java
+++ b/src/main/java/io/vertx/ext/mail/impl/sasl/AuthXOAUTH2.java
@@ -60,7 +60,7 @@ class AuthXOAUTH2 extends AuthBaseClass {
           response.containsKey("schemes") &&
           response.containsKey("scope")) {
 
-          LOG.debug("XOAUTH2 Error Response: " + data);
+          LOG.warn("XOAUTH2 Error Response: " + data);
           // if there is a next step we're receiving an error
           // protocol expects a empty response
           return "";

--- a/src/test/java/io/vertx/ext/mail/SMTPTestBase.java
+++ b/src/test/java/io/vertx/ext/mail/SMTPTestBase.java
@@ -54,7 +54,7 @@ public abstract class SMTPTestBase extends VertxTestBase {
    * this is used to construct the Async objects and do the
    * assert operations
    */
-  TestContext testContext;
+  protected TestContext testContext;
 
   /**
    * @return

--- a/src/test/java/io/vertx/ext/mail/impl/MailAuthChainTest.java
+++ b/src/test/java/io/vertx/ext/mail/impl/MailAuthChainTest.java
@@ -1,0 +1,254 @@
+/*
+ *  Copyright (c) 2011-2019 The original author or authors
+ *
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  and Apache License v2.0 which accompanies this distribution.
+ *
+ *       The Eclipse Public License is available at
+ *       http://www.eclipse.org/legal/epl-v10.html
+ *
+ *       The Apache License v2.0 is available at
+ *       http://www.opensource.org/licenses/apache2.0.php
+ *
+ *  You may elect to redistribute this code under either of these licenses.
+ */
+
+package io.vertx.ext.mail.impl;
+
+import io.vertx.ext.mail.MailClient;
+import io.vertx.ext.mail.MailMessage;
+import io.vertx.ext.mail.PassOnce;
+import io.vertx.ext.mail.SMTPTestDummy;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Tests authentication chain.
+ *
+ * Keep it in the impl package to be able to test internal state like the default authentication mechanism after
+ * first successful authentication.
+ *
+ * @author <a href="mailto:aoingl@gmail.com">Lin Gao</a>
+ */
+@RunWith(VertxUnitRunner.class)
+public class MailAuthChainTest extends SMTPTestDummy {
+
+  // XOAUTH2 failed, but next LOGIN succeeds
+  @Test
+  public void authChainTest(TestContext testContext) {
+    this.testContext = testContext;
+    smtpServer.setDialogue(
+      "220 smtp.gmail.com ESMTP o8sm3958210pjs.6 - gsmtp",
+      "EHLO localhost",
+      "250-smtp.gmail.com at your service, [209.132.188.80]\n" +
+        "250-SIZE 35882577\n" +
+        "250-8BITMIME\n" +
+        "250-AUTH LOGIN PLAIN XOAUTH2 PLAIN-CLIENTTOKEN OAUTHBEARER XOAUTH\n" +
+        "250-ENHANCEDSTATUSCODES\n" +
+        "250-PIPELINING\n" +
+        "250-CHUNKING\n" +
+        "250 SMTPUTF8",
+      "AUTH XOAUTH2 dXNlcj14eHgBYXV0aD1CZWFyZXIgeXl5AQE=",
+      "334 eyJzdGF0dXMiOiI0MDAiLCJzY2hlbWVzIjoiQmVhcmVyIiwic2NvcGUiOiJodHRwczovL21haWwuZ29vZ2xlLmNvbS8ifQ==",
+      "",
+      "535-5.7.8 Username and Password not accepted. Learn more at\n" +
+        "535 5.7.8  https://support.google.com/mail/?p=BadCredentials o8sm3958210pjs.6 - gsmtp",
+      "AUTH LOGIN",
+      "334 VXNlcm5hbWU6",
+      "eHh4",
+      "334 UGFzc3dvcmQ6",
+      "eXl5",
+      "235 2.7.0 Accepted",
+      "MAIL FROM",
+      "250 2.1.0 Ok",
+      "RCPT TO",
+      "250 2.1.5 Ok",
+      "DATA",
+      "354 End data with <CR><LF>.<CR><LF>",
+      "250 2.0.0 Ok: queued as ABCD"
+    ).setCloseImmediately(true);
+    final MailClient mailClient = mailClientLogin();
+    final MailMessage email = exampleMessage();
+    MailClientImpl clientImpl = (MailClientImpl)mailClient;
+    Async async = testContext.async();
+    PassOnce pass1 = new PassOnce(testContext::fail);
+    PassOnce pass2 = new PassOnce(testContext::fail);
+    assertNull(clientImpl.getConnectionPool().getAuthOperationFactory().getAuthMethod());
+    mailClient.sendMail(email, r1 -> {
+      pass1.passOnce();
+      assertTrue(r1.succeeded());
+      assertEquals("LOGIN", clientImpl.getConnectionPool().getAuthOperationFactory().getAuthMethod());
+      smtpServer.setDialogue(
+        "220 smtp.gmail.com ESMTP o8sm3958210pjs.6 - gsmtp",
+        "EHLO localhost",
+        "250-smtp.gmail.com at your service, [209.132.188.80]\n" +
+          "250-SIZE 35882577\n" +
+          "250-8BITMIME\n" +
+          "250-AUTH LOGIN PLAIN XOAUTH2 PLAIN-CLIENTTOKEN OAUTHBEARER XOAUTH\n" +
+          "250-ENHANCEDSTATUSCODES\n" +
+          "250-PIPELINING\n" +
+          "250-CHUNKING\n" +
+          "250 SMTPUTF8",
+        "AUTH LOGIN",
+        "334 VXNlcm5hbWU6",
+        "eHh4",
+        "334 UGFzc3dvcmQ6",
+        "eXl5",
+        "235 2.7.0 Accepted",
+        "MAIL FROM",
+        "250 2.1.0 Ok",
+        "RCPT TO",
+        "250 2.1.5 Ok",
+        "DATA",
+        "354 End data with <CR><LF>.<CR><LF>",
+        "250 2.0.0 Ok: queued as ABCD",
+        "QUIT",
+        "221 2.0.0 Bye"
+      );
+      mailClient.sendMail(email, r2 -> {
+        pass2.passOnce();
+        mailClient.close();
+        assertTrue(r2.succeeded());
+        async.complete();
+      });
+    });
+  }
+
+  // all auth methods failed
+  @Test
+  public void authChainFailedTest(TestContext testContext) {
+    this.testContext = testContext;
+    smtpServer.setDialogue(
+      "220 smtp.gmail.com ESMTP o8sm3958210pjs.6 - gsmtp",
+      "EHLO localhost",
+      "250-smtp.gmail.com at your service, [209.132.188.80]\n" +
+        "250-SIZE 35882577\n" +
+        "250-8BITMIME\n" +
+        "250-AUTH LOGIN PLAIN XOAUTH2\n" +
+        "250-ENHANCEDSTATUSCODES\n" +
+        "250-PIPELINING\n" +
+        "250-CHUNKING\n" +
+        "250 SMTPUTF8",
+      "AUTH XOAUTH2 dXNlcj14eHgBYXV0aD1CZWFyZXIgeXl5AQE=",
+      "334 eyJzdGF0dXMiOiI0MDAiLCJzY2hlbWVzIjoiQmVhcmVyIiwic2NvcGUiOiJodHRwczovL21haWwuZ29vZ2xlLmNvbS8ifQ==",
+      "",
+      "535-5.7.8 Username and Password not accepted. Learn more at\n" +
+        "535 5.7.8  https://support.google.com/mail/?p=BadCredentials o8sm3958210pjs.6 - gsmtp",
+      "AUTH LOGIN",
+      "334 VXNlcm5hbWU6",
+      "eHh4",
+      "334 UGFzc3dvcmQ6",
+      "eXl5",
+      "435 4.7.8 Error: authentication failed: authentication failure",
+      "AUTH PLAIN AHh4eAB5eXk=",
+      "435 4.7.8 Error: authentication failed: bad protocol / cancel"
+    ).setCloseImmediately(true);
+    final MailClient mailClient = mailClientLogin();
+    final MailMessage email = exampleMessage();
+    MailClientImpl clientImpl = (MailClientImpl)mailClient;
+
+    Async async = testContext.async();
+    PassOnce pass1 = new PassOnce(testContext::fail);
+    assertNull(clientImpl.getConnectionPool().getAuthOperationFactory().getAuthMethod());
+    mailClient.sendMail(email, r1 -> {
+      pass1.passOnce();
+      assertTrue(r1.failed());
+      assertNull(clientImpl.getConnectionPool().getAuthOperationFactory().getAuthMethod());
+      mailClient.close();
+      async.complete();
+    });
+  }
+
+
+  // Default auth: LOGIN failed, then try one-by-one and falls back to PLAIN
+  @Test
+  public void authChainDefaultFailedTest(TestContext testContext) {
+    this.testContext = testContext;
+    smtpServer.setDialogue(
+      "220 smtp.gmail.com ESMTP o8sm3958210pjs.6 - gsmtp",
+      "EHLO localhost",
+      "250-smtp.gmail.com at your service, [209.132.188.80]\n" +
+        "250-SIZE 35882577\n" +
+        "250-8BITMIME\n" +
+        "250-AUTH LOGIN PLAIN XOAUTH2\n" +
+        "250-ENHANCEDSTATUSCODES\n" +
+        "250-PIPELINING\n" +
+        "250-CHUNKING\n" +
+        "250 SMTPUTF8",
+      "AUTH LOGIN",
+      "334 VXNlcm5hbWU6",
+      "eHh4",
+      "334 UGFzc3dvcmQ6",
+      "eXl5",
+      "435 4.7.8 Error: authentication failed: authentication failure",
+      "AUTH XOAUTH2 dXNlcj14eHgBYXV0aD1CZWFyZXIgeXl5AQE=",
+      "334 eyJzdGF0dXMiOiI0MDAiLCJzY2hlbWVzIjoiQmVhcmVyIiwic2NvcGUiOiJodHRwczovL21haWwuZ29vZ2xlLmNvbS8ifQ==",
+      "",
+      "535-5.7.8 Username and Password not accepted. Learn more at\n" +
+        "535 5.7.8  https://support.google.com/mail/?p=BadCredentials o8sm3958210pjs.6 - gsmtp",
+      "AUTH LOGIN",
+      "334 VXNlcm5hbWU6",
+      "eHh4",
+      "334 UGFzc3dvcmQ6",
+      "eXl5",
+      "435 4.7.8 Error: authentication failed: authentication failure",
+      "AUTH PLAIN AHh4eAB5eXk=",
+      "250 2.1.0 Ok",
+      "MAIL FROM",
+      "250 2.1.0 Ok",
+      "RCPT TO",
+      "250 2.1.5 Ok",
+      "DATA",
+      "354 End data with <CR><LF>.<CR><LF>",
+      "250 2.0.0 Ok: queued as ABCD"
+    ).setCloseImmediately(true);
+    final MailClient mailClient = mailClientLogin();
+    final MailMessage email = exampleMessage();
+    MailClientImpl clientImpl = (MailClientImpl)mailClient;
+    // default is LOGIN, but will fail
+    clientImpl.getConnectionPool().getAuthOperationFactory().setAuthMethod("LOGIN");
+    Async async = testContext.async();
+    PassOnce pass1 = new PassOnce(testContext::fail);
+    PassOnce pass2 = new PassOnce(testContext::fail);
+    assertEquals("LOGIN", clientImpl.getConnectionPool().getAuthOperationFactory().getAuthMethod());
+    mailClient.sendMail(email, r1 -> {
+      pass1.passOnce();
+      assertTrue(r1.succeeded());
+      assertEquals("PLAIN", clientImpl.getConnectionPool().getAuthOperationFactory().getAuthMethod());
+      smtpServer.setDialogue(
+        "220 smtp.gmail.com ESMTP o8sm3958210pjs.6 - gsmtp",
+        "EHLO localhost",
+        "250-smtp.gmail.com at your service, [209.132.188.80]\n" +
+          "250-SIZE 35882577\n" +
+          "250-8BITMIME\n" +
+          "250-AUTH LOGIN PLAIN XOAUTH2 PLAIN-CLIENTTOKEN OAUTHBEARER XOAUTH\n" +
+          "250-ENHANCEDSTATUSCODES\n" +
+          "250-PIPELINING\n" +
+          "250-CHUNKING\n" +
+          "250 SMTPUTF8",
+        "AUTH PLAIN AHh4eAB5eXk=",
+        "250 2.1.0 Ok",
+        "MAIL FROM",
+        "250 2.1.0 Ok",
+        "RCPT TO",
+        "250 2.1.5 Ok",
+        "DATA",
+        "354 End data with <CR><LF>.<CR><LF>",
+        "250 2.0.0 Ok: queued as ABCD",
+        "QUIT",
+        "221 2.0.0 Bye"
+      );
+      mailClient.sendMail(email, r2 -> {
+        pass2.passOnce();
+        mailClient.close();
+        assertTrue(r2.succeeded());
+        async.complete();
+      });
+    });
+  }
+
+}


### PR DESCRIPTION
Fixes: #124 

Changes in the PR in summary:

* Try next authentication mechanism in preference order if current failed in SMTPAuthentication
* Remember the last successful authentication method as default on in AuthOperationFactory
* Update log level of XOAUTH2 to warning
* Revert the order between `LOGIN` and `PLAIN` in the preference order
* Added tests on auth failures