### PR TITLE
[Issue-129] Fix test failures caused by JSON RFC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ src/gen
 .vertx
 sonar-project.properties
 .sonar*
+generated

--- a/src/test/java/io/vertx/ext/mail/MailAttachmentTest.java
+++ b/src/test/java/io/vertx/ext/mail/MailAttachmentTest.java
@@ -36,7 +36,7 @@ public class MailAttachmentTest {
   @Test
   public void testToJson() {
     assertEquals("{}", MailAttachment.create().toJson().encode());
-    assertEquals("{\"data\":\"ZGF0YQ==\",\"contentType\":\"text/plain\",\"disposition\":\"inline\",\"description\":\"description\",\"contentId\":\"randomstring\",\"headers\":{}}",
+    assertEquals("{\"data\":\"ZGF0YQ\",\"contentType\":\"text/plain\",\"disposition\":\"inline\",\"description\":\"description\",\"contentId\":\"randomstring\",\"headers\":{}}",
       MailAttachment.create()
         .setData(Buffer.buffer("data"))
         .setContentType("text/plain")
@@ -48,7 +48,7 @@ public class MailAttachmentTest {
 
     JsonObject json = MailAttachment.create()
       .setData(Buffer.buffer("hello\"\0\u0001\t\r\n\u00ffx\u00a0\u00a1<>")).toJson();
-    assertEquals("{\"data\":\"aGVsbG8iAAEJDQrDv3jCoMKhPD4=\"}", json.encode());
+    assertEquals("{\"data\":\"aGVsbG8iAAEJDQrDv3jCoMKhPD4\"}", json.encode());
   }
 
   @Test
@@ -96,7 +96,7 @@ public class MailAttachmentTest {
 
   @Test
   public void testConstructorFromJson() {
-    final String jsonString = "{\"data\":\"YXNkZmc=\",\"name\":\"filename.jpg\",\"headers\":{\"Content-ID\":[\"<image1@example.org\"],\"Header\":[\"Value\"]}}";
+    final String jsonString = "{\"data\":\"YXNkZmc\",\"name\":\"filename.jpg\",\"headers\":{\"Content-ID\":[\"<image1@example.org\"],\"Header\":[\"Value\"]}}";
     JsonObject json = new JsonObject(jsonString);
 
     MailAttachment message = MailAttachment.create(json);

--- a/src/test/java/io/vertx/ext/mail/MailMessageTest.java
+++ b/src/test/java/io/vertx/ext/mail/MailMessageTest.java
@@ -55,7 +55,7 @@ public class MailMessageTest {
     MailMessage message = new MailMessage("a", "b", "c", "d");
     message.setAttachment(attachment);
     assertEquals(
-      "{\"from\":\"a\",\"to\":[\"b\"],\"subject\":\"c\",\"text\":\"d\",\"attachment\":[{\"data\":\"YXNkZmFzZGY=\",\"name\":\"file.txt\"}]}",
+      "{\"from\":\"a\",\"to\":[\"b\"],\"subject\":\"c\",\"text\":\"d\",\"attachment\":[{\"data\":\"YXNkZmFzZGY\",\"name\":\"file.txt\"}]}",
       message.toJson().encode());
   }
 
@@ -67,7 +67,7 @@ public class MailMessageTest {
     MailMessage message = new MailMessage();
     message.setAttachment(list);
     assertEquals(
-      "{\"attachment\":[{\"data\":\"YXNkZmFzZGY=\",\"name\":\"file.txt\"},{\"data\":\"eHh4eHg=\",\"name\":\"file2.txt\"}]}",
+      "{\"attachment\":[{\"data\":\"YXNkZmFzZGY\",\"name\":\"file.txt\"},{\"data\":\"eHh4eHg\",\"name\":\"file2.txt\"}]}",
       message.toJson().encode());
   }
 
@@ -122,10 +122,10 @@ public class MailMessageTest {
 
   @Test
   public void testConstructorFromJsonAttachment() {
-    final String jsonString = "{\"attachment\":[{\"data\":\"YXNkZmFzZGY=\",\"name\":\"file.txt\"},{\"data\":\"eHh4eHg=\",\"name\":\"file2.txt\"}]}";
+    final String jsonString = "{\"attachment\":[{\"data\":\"YXNkZmFzZGY\",\"name\":\"file.txt\"},{\"data\":\"eHh4eHg\",\"name\":\"file2.txt\"}]}";
     assertEquals(jsonString, new MailMessage(new JsonObject(jsonString)).toJson().encode());
-    final String jsonString2 = "{\"attachment\":{\"data\":\"YXNkZmFzZGY=\",\"name\":\"file.txt\"}}";
-    final String jsonString3 = "{\"attachment\":[{\"data\":\"YXNkZmFzZGY=\",\"name\":\"file.txt\"}]}";
+    final String jsonString2 = "{\"attachment\":{\"data\":\"YXNkZmFzZGY\",\"name\":\"file.txt\"}}";
+    final String jsonString3 = "{\"attachment\":[{\"data\":\"YXNkZmFzZGY\",\"name\":\"file.txt\"}]}";
     assertEquals(jsonString3, new MailMessage(new JsonObject(jsonString2)).toJson().encode());
   }
 
@@ -169,8 +169,8 @@ public class MailMessageTest {
 
     message2.getAttachment().get(0).setData(Buffer.buffer("message2"));
 
-    assertEquals("{\"attachment\":[{\"data\":\"bWVzc2FnZQ==\"}]}", message.toJson().encode());
-    assertEquals("{\"attachment\":[{\"data\":\"bWVzc2FnZTI=\"}]}", message2.toJson().encode());
+    assertEquals("{\"attachment\":[{\"data\":\"bWVzc2FnZQ\"}]}", message.toJson().encode());
+    assertEquals("{\"attachment\":[{\"data\":\"bWVzc2FnZTI\"}]}", message2.toJson().encode());
   }
 
   @Test

--- a/src/test/java/io/vertx/ext/mail/SMTPTestBase.java
+++ b/src/test/java/io/vertx/ext/mail/SMTPTestBase.java
@@ -197,11 +197,11 @@ public abstract class SMTPTestBase extends VertxTestBase {
         testContext.fail("this test should throw an Exception");
       } else {
         final Throwable cause = result.cause();
-        log.warn("got exception", cause);
         if(exceptionClass == null || exceptionClass.equals(cause.getClass())) {
           async.complete();
         } else {
-          testContext.fail("didn't get expected exception "+exceptionClass+" but "+cause.getClass());
+          log.warn("got exception", cause);
+          testContext.fail("didn't get expected exception " + exceptionClass + " but " + cause.getClass());
         }
       }
     });


### PR DESCRIPTION
Fixes: #129 

Changes in the PR:
- Ignore `generated` from version control
- Fix test failures by removing the `=` padding according to the changes in vertx-core
- Log the warning message when the test will fail in case of testing exceptions.