### PR TITLE
fix email format bug

### DIFF
--- a/src/main/java/io/vertx/ext/mail/impl/SMTPSendMail.java
+++ b/src/main/java/io/vertx/ext/mail/impl/SMTPSendMail.java
@@ -169,7 +169,7 @@ class SMTPSendMail {
     if (i + 1 < recipientAddrs.size()) {
       rcptToCmd(recipientAddrs, i + 1);
     } else {
-      if (mailResult.getRecipients().size() > 0) {
+      if (!mailResult.getRecipients().isEmpty()) {
         dataCmd();
       } else {
         log.warn("no recipient addresses were accepted, not sending mail");
@@ -285,7 +285,7 @@ class SMTPSendMail {
   private void sendMailHeaders(List<Map.Entry<String, String>> headers, int i, Promise<Void> promise) {
     if (i < headers.size()) {
       Map.Entry<String, String> header = headers.get(i);
-      String entryString = header.getKey() + ": " + header.getValue() + "\n";
+      String entryString = header.getKey() + ": " + header.getValue();
       Promise<Void> next = Promise.promise();
       next.future().setHandler(v -> {
         if (v.succeeded()) {


### PR DESCRIPTION
Motivation:

When I use the client to send email, the email is sent out but the format is incorrect . Finally, I found the problem is related with the header, which append one more '\n' at last. The appender should be '\r\n' or not at all? Thanks.

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
