### PR TITLE
[Issue-193] Rename MessageCanonic to CanonicalizationAlgorithm

### DIFF
--- a/src/main/asciidoc/dataobjects.adoc
+++ b/src/main/asciidoc/dataobjects.adoc
@@ -18,8 +18,8 @@
 |[[auid]]`@auid`|`String`|+++
 Sets the Agent or User Identifier(AUID)
 +++
-|[[bodyCanonic]]`@bodyCanonic`|`link:enums.html#MessageCanonic[MessageCanonic]`|+++
-Sets the message canonicalization for email body.
+|[[bodyCanonAlgo]]`@bodyCanonAlgo`|`link:enums.html#CanonicalizationAlgorithm[CanonicalizationAlgorithm]`|+++
+Sets the canonicalization algorithm for mail body.
 +++
 |[[bodyLimit]]`@bodyLimit`|`Number (int)`|+++
 Sets the body limit to sign.
@@ -32,8 +32,8 @@ Sets the expire time in seconds when the signature sign will be expired.
 
  Success call of this method indicates that the signature sign timestamp is enabled.
 +++
-|[[headerCanonic]]`@headerCanonic`|`link:enums.html#MessageCanonic[MessageCanonic]`|+++
-Sets the message canonicalization for email signedHeaders.
+|[[headerCanonAlgo]]`@headerCanonAlgo`|`link:enums.html#CanonicalizationAlgorithm[CanonicalizationAlgorithm]`|+++
+Sets the canonicalization algorithm for signed headers.
 +++
 |[[privateKey]]`@privateKey`|`String`|+++
 Sets the PKCS#8 format private key used to sign the email.

--- a/src/main/asciidoc/enums.adoc
+++ b/src/main/asciidoc/enums.adoc
@@ -1,5 +1,22 @@
 = Enums
 
+[[CanonicalizationAlgorithm]]
+== CanonicalizationAlgorithm
+
+++++
+
+ Canonicalization Algorithm for DKIM.
+++++
+'''
+
+[cols=">25%,75%"]
+[frame="topbot"]
+|===
+^|Name | Description
+|[[SIMPLE]]`SIMPLE`|-
+|[[RELAXED]]`RELAXED`|-
+|===
+
 [[DKIMSignAlgorithm]]
 == DKIMSignAlgorithm
 
@@ -43,23 +60,6 @@
 |[[NONE]]`NONE`|-
 |[[REQUIRED]]`REQUIRED`|-
 |[[XOAUTH2]]`XOAUTH2`|-
-|===
-
-[[MessageCanonic]]
-== MessageCanonic
-
-++++
-
- Message canonicalization for DKIM.
-++++
-'''
-
-[cols=">25%,75%"]
-[frame="topbot"]
-|===
-^|Name | Description
-|[[SIMPLE]]`SIMPLE`|-
-|[[RELAXED]]`RELAXED`|-
 |===
 
 [[StartTLSOptions]]

--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -230,8 +230,8 @@ The DKIMSignOptions object has the following properties
 * `sdid` *required*, String, Singing Domain Identifier(SDID), normally it is the domain of the SMTP server.
 * `auid` optional, String, the Agent or User Identifier(AUID), default is `@` plus `sdid`
 * `selector` *required*, String, the selector used to query public key.
-* `headerCanonic` MessageCanonic algorithm used for headers, one of `simple`(default) and `relaxed`.
-* `bodyCanonic` MessageCanonic algorithm used for body hashing, one of `simple`(default) and `relaxed`.
+* `headerCanonAlgo` Canonicalization algorithm used for mail headers, one of `simple`(default) and `relaxed`.
+* `bodyCanonAlgo` Canonicalization algorithm used for mail body, one of `simple`(default) and `relaxed`.
 * `bodyLimit` optional, int, how long of the body used to calculate the body hash.
 * `signatureTimestamp` optional, boolean, if includes timestamp in the `DKIM-SIgnature` tags list. default is false
 * `expireTime` optional, long, expire time in seconds when the signature sign will be expired from now.

--- a/src/main/java/io/vertx/ext/mail/CanonicalizationAlgorithm.java
+++ b/src/main/java/io/vertx/ext/mail/CanonicalizationAlgorithm.java
@@ -20,21 +20,21 @@ import io.vertx.codegen.annotations.VertxGen;
 
 /**
  *
- * Message canonicalization for DKIM.
+ * Canonicalization Algorithm for DKIM.
  *
  * @author <a href="mailto: aoingl@gmail.com">Lin Gao</a>
  */
 @VertxGen
-public enum MessageCanonic {
+public enum CanonicalizationAlgorithm {
   SIMPLE, // simple
   RELAXED; // relaxed
 
   /**
-   * Gets the message canonicalization representation.
+   * Gets the canonicalization algorithm representation.
    *
-   * @return the message canonicalization representation
+   * @return the canonicalization algorithm representation
    */
-  public String canonic() {
+  public String algoName() {
     return this.name().toLowerCase();
   }
 

--- a/src/main/java/io/vertx/ext/mail/DKIMSignOptions.java
+++ b/src/main/java/io/vertx/ext/mail/DKIMSignOptions.java
@@ -55,8 +55,8 @@ public class DKIMSignOptions {
   private String sdid;
   private String auid;
   private String selector;
-  private MessageCanonic headerCanonic = MessageCanonic.SIMPLE;
-  private MessageCanonic bodyCanonic = MessageCanonic.SIMPLE;
+  private CanonicalizationAlgorithm headerCanonAlgo = CanonicalizationAlgorithm.SIMPLE;
+  private CanonicalizationAlgorithm bodyCanonAlgo = CanonicalizationAlgorithm.SIMPLE;
   private int bodyLimit = -1;
   private boolean signatureTimestamp;
   private long expireTime = -1L;
@@ -81,8 +81,8 @@ public class DKIMSignOptions {
     sdid = other.sdid;
     auid = other.auid;
     selector = other.selector;
-    headerCanonic = other.headerCanonic;
-    bodyCanonic = other.bodyCanonic;
+    headerCanonAlgo = other.headerCanonAlgo;
+    bodyCanonAlgo = other.bodyCanonAlgo;
     bodyLimit = other.bodyLimit;
     signatureTimestamp = other.signatureTimestamp;
     expireTime = other.expireTime;
@@ -251,42 +251,42 @@ public class DKIMSignOptions {
   }
 
   /**
-   * Gets the signedHeaders message canonicalization.
+   * Gets the canonicalization algorithm for signed headers.
    *
-   * @return the message canonicalization for the email signedHeaders
+   * @return the canonicalization algorithm for signed headers
    */
-  public MessageCanonic getHeaderCanonic() {
-    return headerCanonic;
+  public CanonicalizationAlgorithm getHeaderCanonAlgo() {
+    return headerCanonAlgo;
   }
 
   /**
-   * Sets the message canonicalization for email signedHeaders.
+   * Sets the canonicalization algorithm for signed headers.
    *
-   * @param headerCanonic the message canonicalization for email signedHeaders
+   * @param headerCanonAlgo the canonicalization algorithm for signed headers
    * @return a reference to this, so the API can be used fluently
    */
-  public DKIMSignOptions setHeaderCanonic(MessageCanonic headerCanonic) {
-    this.headerCanonic = headerCanonic;
+  public DKIMSignOptions setHeaderCanonAlgo(CanonicalizationAlgorithm headerCanonAlgo) {
+    this.headerCanonAlgo = headerCanonAlgo;
     return this;
   }
 
   /**
-   * Gets the email body message canonicalization.
+   * Gets the canonicalization algorithm for mail body.
    *
-   * @return the message canonicalization for the email body
+   * @return the canonicalization algorithm for mail body
    */
-  public MessageCanonic getBodyCanonic() {
-    return bodyCanonic;
+  public CanonicalizationAlgorithm getBodyCanonAlgo() {
+    return bodyCanonAlgo;
   }
 
   /**
-   * Sets the message canonicalization for email body.
+   * Sets the canonicalization algorithm for mail body.
    *
-   * @param bodyCanonic the message canonicalization for email body
+   * @param bodyCanonAlgo the canonicalization algorithm for mail body
    * @return a reference to this, so the API can be used fluently
    */
-  public DKIMSignOptions setBodyCanonic(MessageCanonic bodyCanonic) {
-    this.bodyCanonic = bodyCanonic;
+  public DKIMSignOptions setBodyCanonAlgo(CanonicalizationAlgorithm bodyCanonAlgo) {
+    this.bodyCanonAlgo = bodyCanonAlgo;
     return this;
   }
 
@@ -415,7 +415,7 @@ public class DKIMSignOptions {
   }
 
   private List<Object> getList() {
-    return Arrays.asList(privateKey, privateKeyPath, signAlgo, signedHeaders, sdid, selector, headerCanonic, bodyCanonic
+    return Arrays.asList(privateKey, privateKeyPath, signAlgo, signedHeaders, sdid, selector, headerCanonAlgo, bodyCanonAlgo
     , auid, bodyLimit, signatureTimestamp, expireTime, copiedHeaders);
   }
 

--- a/src/main/java/io/vertx/ext/mail/impl/dkim/DKIMSigner.java
+++ b/src/main/java/io/vertx/ext/mail/impl/dkim/DKIMSigner.java
@@ -25,7 +25,7 @@ import io.vertx.core.streams.Pipe;
 import io.vertx.core.streams.ReadStream;
 import io.vertx.core.streams.WriteStream;
 import io.vertx.ext.mail.DKIMSignOptions;
-import io.vertx.ext.mail.MessageCanonic;
+import io.vertx.ext.mail.CanonicalizationAlgorithm;
 import io.vertx.ext.mail.mailencoder.EncodedPart;
 import io.vertx.ext.mail.mailencoder.Utils;
 
@@ -135,10 +135,10 @@ public class DKIMSigner {
     sb.append("v=1; ");
     // sign algorithm
     sb.append("a=").append(this.dkimSignOptions.getSignAlgo().dkimAlgoName()).append("; ");
-    // optional message canonic
-    MessageCanonic bodyCanonic = this.dkimSignOptions.getBodyCanonic();
-    MessageCanonic headerCanonic = this.dkimSignOptions.getHeaderCanonic();
-    sb.append("c=").append(headerCanonic.canonic()).append("/").append(bodyCanonic.canonic()).append("; ");
+    // optional message algoName
+    CanonicalizationAlgorithm bodyCanonic = this.dkimSignOptions.getBodyCanonAlgo();
+    CanonicalizationAlgorithm headerCanonic = this.dkimSignOptions.getHeaderCanonAlgo();
+    sb.append("c=").append(headerCanonic.algoName()).append("/").append(bodyCanonic.algoName()).append("; ");
 
     // sdid
     String sdid = dkimQuotedPrintable(this.dkimSignOptions.getSdid());
@@ -454,11 +454,11 @@ public class DKIMSigner {
    * @return the canonicalization email header in format of 'Name':'Value'.
    */
   String canonicHeader(String emailHeaderName, String emailHeaderValue) {
-    if (this.dkimSignOptions.getHeaderCanonic() == MessageCanonic.SIMPLE) {
+    if (this.dkimSignOptions.getHeaderCanonAlgo() == CanonicalizationAlgorithm.SIMPLE) {
       return emailHeaderName + ": " + emailHeaderValue;
     }
     String headerName = emailHeaderName.trim().toLowerCase();
-    return headerName + ":" + canonicLine(emailHeaderValue, this.dkimSignOptions.getHeaderCanonic());
+    return headerName + ":" + canonicalLine(emailHeaderValue, this.dkimSignOptions.getHeaderCanonAlgo());
   }
 
   String dkimMailBody(String mailBody) {
@@ -472,8 +472,8 @@ public class DKIMSigner {
   }
 
   // this is shared by header and body for each line's canonicalization.
-  private String canonicLine(String line, MessageCanonic canonic) {
-    if (MessageCanonic.RELAXED == canonic) {
+  private String canonicalLine(String line, CanonicalizationAlgorithm canon) {
+    if (CanonicalizationAlgorithm.RELAXED == canon) {
       line = line.replaceAll("[\r\n\t ]+", " ");
       line = line.replaceAll("[\r\n\t ]+$", "");
     }
@@ -481,7 +481,7 @@ public class DKIMSigner {
   }
 
   String canonicBodyLine(String line) {
-    return canonicLine(line, this.dkimSignOptions.getBodyCanonic());
+    return canonicalLine(line, this.dkimSignOptions.getBodyCanonAlgo());
   }
 
 }

--- a/src/test/java/io/vertx/ext/mail/MailWithDKIMSignTest.java
+++ b/src/test/java/io/vertx/ext/mail/MailWithDKIMSignTest.java
@@ -90,7 +90,7 @@ public class MailWithDKIMSignTest extends SMTPTestWiser {
     this.testContext = testContext;
     MailMessage message = exampleMessage().setText(TEXT_BODY);
     DKIMSignOptions dkimOps = new DKIMSignOptions(dkimOptionsBase)
-      .setHeaderCanonic(MessageCanonic.SIMPLE).setBodyCanonic(MessageCanonic.SIMPLE);
+      .setHeaderCanonAlgo(CanonicalizationAlgorithm.SIMPLE).setBodyCanonAlgo(CanonicalizationAlgorithm.SIMPLE);
     testSuccess(dkimMailClient(dkimOps), message, () -> {
       testContext.assertEquals(TEXT_BODY + "\n", TestUtils.conv2nl(TestUtils.inputStreamToString(wiser.getMessages().get(0).getMimeMessage().getInputStream())));
       testDKIMSign(dkimOps, testContext);
@@ -102,7 +102,7 @@ public class MailWithDKIMSignTest extends SMTPTestWiser {
     this.testContext = testContext;
     MailMessage message = exampleMessage().setText(TEXT_BODY);
     DKIMSignOptions dkimOps = new DKIMSignOptions(dkimOptionsBase)
-      .setHeaderCanonic(MessageCanonic.SIMPLE).setBodyCanonic(MessageCanonic.RELAXED);
+      .setHeaderCanonAlgo(CanonicalizationAlgorithm.SIMPLE).setBodyCanonAlgo(CanonicalizationAlgorithm.RELAXED);
     testSuccess(dkimMailClient(dkimOps), message, () -> {
       testContext.assertEquals(TEXT_BODY + "\n", TestUtils.conv2nl(TestUtils.inputStreamToString(wiser.getMessages().get(0).getMimeMessage().getInputStream())));
       testDKIMSign(dkimOps, testContext);
@@ -114,7 +114,7 @@ public class MailWithDKIMSignTest extends SMTPTestWiser {
     this.testContext = testContext;
     MailMessage message = exampleMessage().setText(TEXT_BODY);
     DKIMSignOptions dkimOps = new DKIMSignOptions(dkimOptionsBase)
-      .setHeaderCanonic(MessageCanonic.RELAXED).setBodyCanonic(MessageCanonic.RELAXED);
+      .setHeaderCanonAlgo(CanonicalizationAlgorithm.RELAXED).setBodyCanonAlgo(CanonicalizationAlgorithm.RELAXED);
     testSuccess(dkimMailClient(dkimOps), message, () -> {
       testContext.assertEquals(TEXT_BODY + "\n", TestUtils.conv2nl(TestUtils.inputStreamToString(wiser.getMessages().get(0).getMimeMessage().getInputStream())));
       testDKIMSign(dkimOps, testContext);
@@ -128,7 +128,7 @@ public class MailWithDKIMSignTest extends SMTPTestWiser {
     MailMessage message = exampleMessage().setText(TEXT_BODY).addHeader("Received", "by 2002:ab3:7755:0:0:0:0:0 with SMTP id z21csp2085702lti")
       .addHeader("Received", "by 2002:a05:620a:147c:: with SMTP id j28mr519391qkl.13.1575424987504");
     DKIMSignOptions dkimOps = new DKIMSignOptions(dkimOptionsBase).setSignedHeaders(signedHeaders)
-      .setHeaderCanonic(MessageCanonic.SIMPLE).setBodyCanonic(MessageCanonic.SIMPLE);
+      .setHeaderCanonAlgo(CanonicalizationAlgorithm.SIMPLE).setBodyCanonAlgo(CanonicalizationAlgorithm.SIMPLE);
     testSuccess(dkimMailClient(dkimOps), message, () -> {
       testContext.assertEquals(TEXT_BODY + "\n", TestUtils.conv2nl(TestUtils.inputStreamToString(wiser.getMessages().get(0).getMimeMessage().getInputStream())));
       testDKIMSign(dkimOps, signedHeaders, testContext);
@@ -143,7 +143,7 @@ public class MailWithDKIMSignTest extends SMTPTestWiser {
       .addHeader("Received", "by 2002:a05:620a:147c:: with SMTP id j28mr519391qkl.13.1575424987504")
       .addHeader("Received", "by 2005:a15:725a:579c:: with SMTP id j28mR876591qkl.13.1575473987504");
     DKIMSignOptions dkimOps = new DKIMSignOptions(dkimOptionsBase).setSignedHeaders(signedHeaders)
-      .setHeaderCanonic(MessageCanonic.SIMPLE).setBodyCanonic(MessageCanonic.RELAXED);
+      .setHeaderCanonAlgo(CanonicalizationAlgorithm.SIMPLE).setBodyCanonAlgo(CanonicalizationAlgorithm.RELAXED);
     testSuccess(dkimMailClient(dkimOps), message, () -> {
       testContext.assertEquals(TEXT_BODY + "\n", TestUtils.conv2nl(TestUtils.inputStreamToString(wiser.getMessages().get(0).getMimeMessage().getInputStream())));
       testDKIMSign(dkimOps, signedHeaders, testContext);
@@ -157,7 +157,7 @@ public class MailWithDKIMSignTest extends SMTPTestWiser {
     MailMessage message = exampleMessage().setText(TEXT_BODY).addHeader("Received", "by 2002:ab3:7755:0:0:0:0:0 with SMTP id z21csp2085702lti")
       .addHeader("Received", "by 2002:a05:620a:147c:: with SMTP id j28mr519391qkl.13.1575424987504");
     DKIMSignOptions dkimOps = new DKIMSignOptions(dkimOptionsBase).setSignedHeaders(signedHeaders)
-      .setHeaderCanonic(MessageCanonic.RELAXED).setBodyCanonic(MessageCanonic.SIMPLE);
+      .setHeaderCanonAlgo(CanonicalizationAlgorithm.RELAXED).setBodyCanonAlgo(CanonicalizationAlgorithm.SIMPLE);
     testSuccess(dkimMailClient(dkimOps), message, () -> {
       testContext.assertEquals(TEXT_BODY + "\n", TestUtils.conv2nl(TestUtils.inputStreamToString(wiser.getMessages().get(0).getMimeMessage().getInputStream())));
       testDKIMSign(dkimOps, signedHeaders, testContext);
@@ -172,7 +172,7 @@ public class MailWithDKIMSignTest extends SMTPTestWiser {
       .addHeader("Received", "by 2002:ab3:7755:0:0:0:0:0 with SMTP id z21csp2085702lti")
       .addHeader("Received", "by 2002:a05:620a:147c:: with SMTP id j28mr519391qkl.13.1575424987504");
     DKIMSignOptions dkimOps = new DKIMSignOptions(dkimOptionsBase).setSignedHeaders(signedHeaders)
-      .setHeaderCanonic(MessageCanonic.RELAXED).setBodyCanonic(MessageCanonic.RELAXED);
+      .setHeaderCanonAlgo(CanonicalizationAlgorithm.RELAXED).setBodyCanonAlgo(CanonicalizationAlgorithm.RELAXED);
     testSuccess(dkimMailClient(dkimOps), message, () -> {
       testContext.assertEquals(TEXT_BODY + "\n", TestUtils.conv2nl(TestUtils.inputStreamToString(wiser.getMessages().get(0).getMimeMessage().getInputStream())));
       testDKIMSign(dkimOps, signedHeaders, testContext);
@@ -184,7 +184,7 @@ public class MailWithDKIMSignTest extends SMTPTestWiser {
     this.testContext = testContext;
     MailMessage message = exampleMessage().setText(TEXT_BODY);
     DKIMSignOptions dkimOps = new DKIMSignOptions(dkimOptionsBase).setBodyLimit(100)
-      .setHeaderCanonic(MessageCanonic.RELAXED).setBodyCanonic(MessageCanonic.RELAXED);
+      .setHeaderCanonAlgo(CanonicalizationAlgorithm.RELAXED).setBodyCanonAlgo(CanonicalizationAlgorithm.RELAXED);
     testSuccess(dkimMailClient(dkimOps), message, () -> {
       testContext.assertEquals(TEXT_BODY + "\n", TestUtils.conv2nl(TestUtils.inputStreamToString(wiser.getMessages().get(0).getMimeMessage().getInputStream())));
       testDKIMSign(dkimOps, testContext);
@@ -196,7 +196,7 @@ public class MailWithDKIMSignTest extends SMTPTestWiser {
     this.testContext = testContext;
     MailMessage message = exampleMessage().setText(TEXT_BODY);
     DKIMSignOptions dkimOps = new DKIMSignOptions(dkimOptionsBase).setBodyLimit(20)
-      .setHeaderCanonic(MessageCanonic.RELAXED).setBodyCanonic(MessageCanonic.SIMPLE);
+      .setHeaderCanonAlgo(CanonicalizationAlgorithm.RELAXED).setBodyCanonAlgo(CanonicalizationAlgorithm.SIMPLE);
     testSuccess(dkimMailClient(dkimOps), message, () -> {
       testContext.assertEquals(TEXT_BODY + "\n", TestUtils.conv2nl(TestUtils.inputStreamToString(wiser.getMessages().get(0).getMimeMessage().getInputStream())));
       testDKIMSign(dkimOps, testContext);
@@ -208,7 +208,7 @@ public class MailWithDKIMSignTest extends SMTPTestWiser {
     this.testContext = testContext;
     MailMessage message = exampleMessage().setText(TEXT_BODY);
     DKIMSignOptions dkimOps = new DKIMSignOptions(dkimOptionsBase).setBodyLimit(Integer.MAX_VALUE)
-      .setHeaderCanonic(MessageCanonic.RELAXED).setBodyCanonic(MessageCanonic.SIMPLE);
+      .setHeaderCanonAlgo(CanonicalizationAlgorithm.RELAXED).setBodyCanonAlgo(CanonicalizationAlgorithm.SIMPLE);
     testSuccess(dkimMailClient(dkimOps), message, () -> {
       testContext.assertEquals(TEXT_BODY + "\n", TestUtils.conv2nl(TestUtils.inputStreamToString(wiser.getMessages().get(0).getMimeMessage().getInputStream())));
       testDKIMSign(dkimOps, testContext);
@@ -220,7 +220,7 @@ public class MailWithDKIMSignTest extends SMTPTestWiser {
     this.testContext = testContext;
     MailMessage message = exampleMessage().setText(TEXT_BODY);
     DKIMSignOptions dkimOps = new DKIMSignOptions(dkimOptionsBase)
-      .setHeaderCanonic(MessageCanonic.RELAXED).setBodyCanonic(MessageCanonic.SIMPLE);
+      .setHeaderCanonAlgo(CanonicalizationAlgorithm.RELAXED).setBodyCanonAlgo(CanonicalizationAlgorithm.SIMPLE);
     testSuccess(dkimMailClient(dkimOps), message, () -> {
       testContext.assertEquals(TEXT_BODY + "\n", TestUtils.conv2nl(TestUtils.inputStreamToString(wiser.getMessages().get(0).getMimeMessage().getInputStream())));
       testDKIMSign(dkimOps, testContext);
@@ -233,7 +233,7 @@ public class MailWithDKIMSignTest extends SMTPTestWiser {
     MailMessage message = exampleMessage().setText(TEXT_BODY);
     DKIMSignOptions dkimOps = new DKIMSignOptions(dkimOptionsBase).setExpireTime(2000)
       .setCopiedHeaders(Stream.of("From", "To").collect(Collectors.toList()))
-      .setHeaderCanonic(MessageCanonic.SIMPLE).setBodyCanonic(MessageCanonic.SIMPLE);
+      .setHeaderCanonAlgo(CanonicalizationAlgorithm.SIMPLE).setBodyCanonAlgo(CanonicalizationAlgorithm.SIMPLE);
     testSuccess(dkimMailClient(dkimOps), message, () -> {
       testContext.assertEquals(TEXT_BODY + "\n", TestUtils.conv2nl(TestUtils.inputStreamToString(wiser.getMessages().get(0).getMimeMessage().getInputStream())));
       testDKIMSign(dkimOps, testContext);
@@ -246,7 +246,7 @@ public class MailWithDKIMSignTest extends SMTPTestWiser {
     MailMessage message = exampleMessage().setText(TEXT_BODY);
     DKIMSignOptions dkimOps = new DKIMSignOptions(dkimOptionsBase).setExpireTime(2000)
       .setCopiedHeaders(Stream.of("From", "Not-Existed-Header").collect(Collectors.toList()))
-      .setHeaderCanonic(MessageCanonic.SIMPLE).setBodyCanonic(MessageCanonic.SIMPLE);
+      .setHeaderCanonAlgo(CanonicalizationAlgorithm.SIMPLE).setBodyCanonAlgo(CanonicalizationAlgorithm.SIMPLE);
     testException(dkimMailClient(dkimOps), message, RuntimeException.class);
   }
 
@@ -259,7 +259,7 @@ public class MailWithDKIMSignTest extends SMTPTestWiser {
     MailMessage message = exampleMessage().setText(TEXT_BODY).setAttachment(attachment);
 
     DKIMSignOptions dkimOps = new DKIMSignOptions(dkimOptionsBase)
-      .setHeaderCanonic(MessageCanonic.SIMPLE).setBodyCanonic(MessageCanonic.SIMPLE);
+      .setHeaderCanonAlgo(CanonicalizationAlgorithm.SIMPLE).setBodyCanonAlgo(CanonicalizationAlgorithm.SIMPLE);
     testSuccess(dkimMailClient(dkimOps), message, () -> {
       final MimeMultipart multiPart = (MimeMultipart)wiser.getMessages().get(0).getMimeMessage().getContent();
       testContext.assertEquals(2, multiPart.getCount());
@@ -278,7 +278,7 @@ public class MailWithDKIMSignTest extends SMTPTestWiser {
     MailMessage message = exampleMessage().setText(TEXT_BODY).setAttachment(attachment);
 
     DKIMSignOptions dkimOps = new DKIMSignOptions(dkimOptionsBase)
-      .setHeaderCanonic(MessageCanonic.SIMPLE).setBodyCanonic(MessageCanonic.RELAXED);
+      .setHeaderCanonAlgo(CanonicalizationAlgorithm.SIMPLE).setBodyCanonAlgo(CanonicalizationAlgorithm.RELAXED);
     testSuccess(dkimMailClient(dkimOps), message, () -> {
       final MimeMultipart multiPart = (MimeMultipart)wiser.getMessages().get(0).getMimeMessage().getContent();
       testContext.assertEquals(2, multiPart.getCount());
@@ -297,7 +297,7 @@ public class MailWithDKIMSignTest extends SMTPTestWiser {
     MailMessage message = exampleMessage().setText(TEXT_BODY).setAttachment(attachment);
 
     DKIMSignOptions dkimOps = new DKIMSignOptions(dkimOptionsBase)
-      .setHeaderCanonic(MessageCanonic.RELAXED).setBodyCanonic(MessageCanonic.SIMPLE);
+      .setHeaderCanonAlgo(CanonicalizationAlgorithm.RELAXED).setBodyCanonAlgo(CanonicalizationAlgorithm.SIMPLE);
     testSuccess(dkimMailClient(dkimOps), message, () -> {
       final MimeMultipart multiPart = (MimeMultipart)wiser.getMessages().get(0).getMimeMessage().getContent();
       testContext.assertEquals(2, multiPart.getCount());
@@ -316,7 +316,7 @@ public class MailWithDKIMSignTest extends SMTPTestWiser {
     MailMessage message = exampleMessage().setText(TEXT_BODY).setAttachment(attachment);
 
     DKIMSignOptions dkimOps = new DKIMSignOptions(dkimOptionsBase)
-      .setHeaderCanonic(MessageCanonic.RELAXED).setBodyCanonic(MessageCanonic.RELAXED);
+      .setHeaderCanonAlgo(CanonicalizationAlgorithm.RELAXED).setBodyCanonAlgo(CanonicalizationAlgorithm.RELAXED);
     testSuccess(dkimMailClient(dkimOps), message, () -> {
       final MimeMultipart multiPart = (MimeMultipart)wiser.getMessages().get(0).getMimeMessage().getContent();
       testContext.assertEquals(2, multiPart.getCount());
@@ -340,7 +340,7 @@ public class MailWithDKIMSignTest extends SMTPTestWiser {
       .setAttachment(attachment);
 
     DKIMSignOptions dkimOps = new DKIMSignOptions(dkimOptionsBase)
-      .setHeaderCanonic(MessageCanonic.RELAXED).setBodyCanonic(MessageCanonic.RELAXED);
+      .setHeaderCanonAlgo(CanonicalizationAlgorithm.RELAXED).setBodyCanonAlgo(CanonicalizationAlgorithm.RELAXED);
     testSuccess(dkimMailClient(dkimOps), message, () -> {
 
       // 1. alternative multi part
@@ -379,7 +379,7 @@ public class MailWithDKIMSignTest extends SMTPTestWiser {
       .setAttachment(attachment);
 
     DKIMSignOptions dkimOps = new DKIMSignOptions(dkimOptionsBase).setBodyLimit(500)
-      .setHeaderCanonic(MessageCanonic.RELAXED).setBodyCanonic(MessageCanonic.RELAXED);
+      .setHeaderCanonAlgo(CanonicalizationAlgorithm.RELAXED).setBodyCanonAlgo(CanonicalizationAlgorithm.RELAXED);
     testSuccess(dkimMailClient(dkimOps), message, () -> {
 
       // 1. alternative multi part
@@ -420,7 +420,7 @@ public class MailWithDKIMSignTest extends SMTPTestWiser {
       .setAttachment(attachment);
 
     DKIMSignOptions dkimOps = new DKIMSignOptions(dkimOptionsBase)
-      .setHeaderCanonic(MessageCanonic.RELAXED).setBodyCanonic(MessageCanonic.RELAXED);
+      .setHeaderCanonAlgo(CanonicalizationAlgorithm.RELAXED).setBodyCanonAlgo(CanonicalizationAlgorithm.RELAXED);
     testSuccess(dkimMailClient(dkimOps), message, () -> {
 
       // 1. alternative multi part
@@ -456,7 +456,7 @@ public class MailWithDKIMSignTest extends SMTPTestWiser {
     MailMessage message = exampleMessage().setText(TEXT_BODY).setAttachment(attachment);
 
     DKIMSignOptions dkimOps = new DKIMSignOptions(dkimOptionsBase)
-      .setHeaderCanonic(MessageCanonic.SIMPLE).setBodyCanonic(MessageCanonic.SIMPLE);
+      .setHeaderCanonAlgo(CanonicalizationAlgorithm.SIMPLE).setBodyCanonAlgo(CanonicalizationAlgorithm.SIMPLE);
     testSuccess(dkimMailClient(dkimOps), message, () -> {
       final MimeMultipart multiPart = (MimeMultipart)wiser.getMessages().get(0).getMimeMessage().getContent();
       testContext.assertEquals(2, multiPart.getCount());
@@ -477,7 +477,7 @@ public class MailWithDKIMSignTest extends SMTPTestWiser {
     MailMessage message = exampleMessage().setText(TEXT_BODY).setAttachment(attachment);
 
     DKIMSignOptions dkimOps = new DKIMSignOptions(dkimOptionsBase)
-      .setHeaderCanonic(MessageCanonic.SIMPLE).setBodyCanonic(MessageCanonic.RELAXED);
+      .setHeaderCanonAlgo(CanonicalizationAlgorithm.SIMPLE).setBodyCanonAlgo(CanonicalizationAlgorithm.RELAXED);
     testSuccess(dkimMailClient(dkimOps), message, () -> {
       final MimeMultipart multiPart = (MimeMultipart)wiser.getMessages().get(0).getMimeMessage().getContent();
       testContext.assertEquals(2, multiPart.getCount());
@@ -498,7 +498,7 @@ public class MailWithDKIMSignTest extends SMTPTestWiser {
     MailMessage message = exampleMessage().setText(TEXT_BODY).setAttachment(attachment);
 
     DKIMSignOptions dkimOps = new DKIMSignOptions(dkimOptionsBase)
-      .setHeaderCanonic(MessageCanonic.RELAXED).setBodyCanonic(MessageCanonic.SIMPLE);
+      .setHeaderCanonAlgo(CanonicalizationAlgorithm.RELAXED).setBodyCanonAlgo(CanonicalizationAlgorithm.SIMPLE);
     testSuccess(dkimMailClient(dkimOps), message, () -> {
       final MimeMultipart multiPart = (MimeMultipart)wiser.getMessages().get(0).getMimeMessage().getContent();
       testContext.assertEquals(2, multiPart.getCount());
@@ -519,7 +519,7 @@ public class MailWithDKIMSignTest extends SMTPTestWiser {
     MailMessage message = exampleMessage().setText(TEXT_BODY).setAttachment(attachment);
 
     DKIMSignOptions dkimOps = new DKIMSignOptions(dkimOptionsBase)
-      .setHeaderCanonic(MessageCanonic.RELAXED).setBodyCanonic(MessageCanonic.RELAXED);
+      .setHeaderCanonAlgo(CanonicalizationAlgorithm.RELAXED).setBodyCanonAlgo(CanonicalizationAlgorithm.RELAXED);
     testSuccess(dkimMailClient(dkimOps), message, () -> {
       final MimeMultipart multiPart = (MimeMultipart)wiser.getMessages().get(0).getMimeMessage().getContent();
       testContext.assertEquals(2, multiPart.getCount());
@@ -540,7 +540,7 @@ public class MailWithDKIMSignTest extends SMTPTestWiser {
     MailMessage message = exampleMessage().setText(TEXT_BODY).setAttachment(attachment);
 
     DKIMSignOptions dkimOps = new DKIMSignOptions(dkimOptionsBase).setBodyLimit(100)
-      .setHeaderCanonic(MessageCanonic.RELAXED).setBodyCanonic(MessageCanonic.RELAXED);
+      .setHeaderCanonAlgo(CanonicalizationAlgorithm.RELAXED).setBodyCanonAlgo(CanonicalizationAlgorithm.RELAXED);
     testSuccess(dkimMailClient(dkimOps), message, () -> {
       final MimeMultipart multiPart = (MimeMultipart)wiser.getMessages().get(0).getMimeMessage().getContent();
       testContext.assertEquals(2, multiPart.getCount());
@@ -561,7 +561,7 @@ public class MailWithDKIMSignTest extends SMTPTestWiser {
     MailMessage message = exampleMessage().setText(TEXT_BODY).setAttachment(attachment);
 
     DKIMSignOptions dkimOps = new DKIMSignOptions(dkimOptionsBase).setBodyLimit(50)
-      .setHeaderCanonic(MessageCanonic.RELAXED).setBodyCanonic(MessageCanonic.SIMPLE);
+      .setHeaderCanonAlgo(CanonicalizationAlgorithm.RELAXED).setBodyCanonAlgo(CanonicalizationAlgorithm.SIMPLE);
     testSuccess(dkimMailClient(dkimOps), message, () -> {
       final MimeMultipart multiPart = (MimeMultipart)wiser.getMessages().get(0).getMimeMessage().getContent();
       testContext.assertEquals(2, multiPart.getCount());
@@ -643,7 +643,7 @@ public class MailWithDKIMSignTest extends SMTPTestWiser {
     MailMessage message = exampleMessage().setText(TEXT_BODY).setAttachment(attachment);
 
     DKIMSignOptions dkimOps = new DKIMSignOptions(dkimOptionsBase)
-      .setHeaderCanonic(MessageCanonic.SIMPLE).setBodyCanonic(MessageCanonic.SIMPLE);
+      .setHeaderCanonAlgo(CanonicalizationAlgorithm.SIMPLE).setBodyCanonAlgo(CanonicalizationAlgorithm.SIMPLE);
     testSuccess(dkimMailClient(dkimOps), message, () -> {
       final MimeMultipart multiPart = (MimeMultipart)wiser.getMessages().get(0).getMimeMessage().getContent();
       testContext.assertEquals(2, multiPart.getCount());
@@ -666,7 +666,7 @@ public class MailWithDKIMSignTest extends SMTPTestWiser {
     MailMessage message = exampleMessage().setText(TEXT_BODY).setAttachment(attachment);
 
     DKIMSignOptions dkimOps = new DKIMSignOptions(dkimOptionsBase).setBodyLimit(50)
-      .setHeaderCanonic(MessageCanonic.SIMPLE).setBodyCanonic(MessageCanonic.SIMPLE);
+      .setHeaderCanonAlgo(CanonicalizationAlgorithm.SIMPLE).setBodyCanonAlgo(CanonicalizationAlgorithm.SIMPLE);
     testSuccess(dkimMailClient(dkimOps), message, () -> {
       final MimeMultipart multiPart = (MimeMultipart)wiser.getMessages().get(0).getMimeMessage().getContent();
       testContext.assertEquals(2, multiPart.getCount());
@@ -689,7 +689,7 @@ public class MailWithDKIMSignTest extends SMTPTestWiser {
     MailMessage message = exampleMessage().setText(TEXT_BODY).setAttachment(attachment);
 
     DKIMSignOptions dkimOps = new DKIMSignOptions(dkimOptionsBase)
-      .setHeaderCanonic(MessageCanonic.SIMPLE).setBodyCanonic(MessageCanonic.SIMPLE);
+      .setHeaderCanonAlgo(CanonicalizationAlgorithm.SIMPLE).setBodyCanonAlgo(CanonicalizationAlgorithm.SIMPLE);
     testSuccess(dkimMailClient(dkimOps), message, () -> {
       final MimeMultipart multiPart = (MimeMultipart)wiser.getMessages().get(0).getMimeMessage().getContent();
       testContext.assertEquals(2, multiPart.getCount());
@@ -712,7 +712,7 @@ public class MailWithDKIMSignTest extends SMTPTestWiser {
     MailMessage message = exampleMessage().setText(TEXT_BODY).setAttachment(attachment);
 
     DKIMSignOptions dkimOps = new DKIMSignOptions(dkimOptionsBase).setBodyLimit(50)
-      .setHeaderCanonic(MessageCanonic.SIMPLE).setBodyCanonic(MessageCanonic.SIMPLE);
+      .setHeaderCanonAlgo(CanonicalizationAlgorithm.SIMPLE).setBodyCanonAlgo(CanonicalizationAlgorithm.SIMPLE);
     testSuccess(dkimMailClient(dkimOps), message, () -> {
       final MimeMultipart multiPart = (MimeMultipart)wiser.getMessages().get(0).getMimeMessage().getContent();
       testContext.assertEquals(2, multiPart.getCount());
@@ -739,7 +739,7 @@ public class MailWithDKIMSignTest extends SMTPTestWiser {
     });
     ctx.assertEquals("1", signTags.get("v"));
     ctx.assertEquals(DKIMSignAlgorithm.RSA_SHA256.dkimAlgoName(), signTags.get("a"));
-    ctx.assertEquals(dkimOps.getHeaderCanonic().canonic() + "/" + dkimOps.getBodyCanonic().canonic(), signTags.get("c"));
+    ctx.assertEquals(dkimOps.getHeaderCanonAlgo().algoName() + "/" + dkimOps.getBodyCanonAlgo().algoName(), signTags.get("c"));
     ctx.assertEquals("example.com", signTags.get("d"));
     ctx.assertEquals("lgao", signTags.get("s"));
     ctx.assertEquals(String.join(":", signHeaders), signTags.get("h"));

--- a/src/test/java/io/vertx/ext/mail/impl/dkim/DKIMSignerTest.java
+++ b/src/test/java/io/vertx/ext/mail/impl/dkim/DKIMSignerTest.java
@@ -19,7 +19,7 @@ package io.vertx.ext.mail.impl.dkim;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.mail.DKIMSignAlgorithm;
 import io.vertx.ext.mail.DKIMSignOptions;
-import io.vertx.ext.mail.MessageCanonic;
+import io.vertx.ext.mail.CanonicalizationAlgorithm;
 import org.junit.Test;
 
 import java.util.stream.Collectors;
@@ -64,15 +64,15 @@ public class DKIMSignerTest {
 
     assertTrue(dkimOps.getSignedHeaders().stream().anyMatch(h -> h.equalsIgnoreCase("from")));
     assertEquals(DKIMSignAlgorithm.RSA_SHA256, dkimOps.getSignAlgo());
-    assertEquals(MessageCanonic.SIMPLE, dkimOps.getHeaderCanonic());
-    assertEquals(MessageCanonic.SIMPLE, dkimOps.getBodyCanonic());
+    assertEquals(CanonicalizationAlgorithm.SIMPLE, dkimOps.getHeaderCanonAlgo());
+    assertEquals(CanonicalizationAlgorithm.SIMPLE, dkimOps.getBodyCanonAlgo());
     assertEquals(-1, dkimOps.getBodyLimit());
     assertEquals(-1, dkimOps.getExpireTime());
 
     JsonObject json = dkimOps.toJson();
     assertEquals(DKIMSignAlgorithm.RSA_SHA256, DKIMSignAlgorithm.valueOf(json.getString("signAlgo")));
-    assertEquals(MessageCanonic.SIMPLE.name(), json.getString("headerCanonic"));
-    assertEquals(MessageCanonic.SIMPLE.name(), json.getString("bodyCanonic"));
+    assertEquals(CanonicalizationAlgorithm.SIMPLE.name(), json.getString("headerCanonAlgo"));
+    assertEquals(CanonicalizationAlgorithm.SIMPLE.name(), json.getString("bodyCanonAlgo"));
   }
 
   @Test
@@ -82,20 +82,20 @@ public class DKIMSignerTest {
 
     dkimOps.setAuid("local-part@example.com");
     dkimOps.setSdid("example.com");
-    dkimOps.setBodyCanonic(MessageCanonic.RELAXED);
+    dkimOps.setBodyCanonAlgo(CanonicalizationAlgorithm.RELAXED);
     dkimOps.setBodyLimit(5000);
     dkimOps.setCopiedHeaders(Stream.of("From", "To").collect(Collectors.toList()));
     dkimOps.setSelector("exampleUser");
-    dkimOps.setHeaderCanonic(MessageCanonic.SIMPLE);
+    dkimOps.setHeaderCanonAlgo(CanonicalizationAlgorithm.SIMPLE);
     dkimOps.setPrivateKey(PRIVATE_KEY);
 
     assertEquals("local-part@example.com", dkimOps.getAuid());
     assertEquals("example.com", dkimOps.getSdid());
-    assertEquals(MessageCanonic.RELAXED, dkimOps.getBodyCanonic());
+    assertEquals(CanonicalizationAlgorithm.RELAXED, dkimOps.getBodyCanonAlgo());
     assertEquals(5000, dkimOps.getBodyLimit());
     assertArrayEquals(new String[]{"From", "To"}, dkimOps.getCopiedHeaders().toArray());
     assertEquals("exampleUser", dkimOps.getSelector());
-    assertEquals(MessageCanonic.SIMPLE, dkimOps.getHeaderCanonic());
+    assertEquals(CanonicalizationAlgorithm.SIMPLE, dkimOps.getHeaderCanonAlgo());
 
     DKIMSigner dkimSigner = new DKIMSigner(dkimOps, null);
     assertNotNull(dkimSigner);
@@ -169,7 +169,7 @@ public class DKIMSignerTest {
 
   @Test
   public void testSimpleHeader() {
-    DKIMSignOptions dkimOps = dkimOps().setHeaderCanonic(MessageCanonic.SIMPLE);
+    DKIMSignOptions dkimOps = dkimOps().setHeaderCanonAlgo(CanonicalizationAlgorithm.SIMPLE);
     DKIMSigner signer = new DKIMSigner(dkimOps, null);
     // there will be possible to have \n in the header value, keep it as it is.
     String name = "from";
@@ -195,7 +195,7 @@ public class DKIMSignerTest {
 
   @Test
   public void testRelaxedHeader() {
-    DKIMSignOptions dkimOps = dkimOps().setHeaderCanonic(MessageCanonic.RELAXED);
+    DKIMSignOptions dkimOps = dkimOps().setHeaderCanonAlgo(CanonicalizationAlgorithm.RELAXED);
     DKIMSigner signer = new DKIMSigner(dkimOps, null);
     // there will be possible to have \n in the header value
     String name = "From";
@@ -226,7 +226,7 @@ public class DKIMSignerTest {
 
   @Test
   public void testRelaxedBodyLine() {
-    DKIMSignOptions dkimOps = dkimOps().setBodyCanonic(MessageCanonic.RELAXED);
+    DKIMSignOptions dkimOps = dkimOps().setBodyCanonAlgo(CanonicalizationAlgorithm.RELAXED);
     DKIMSigner signer = new DKIMSigner(dkimOps, null);
     // there will be no \n in each line, so just test whitespaces
     String line = "Line with trailing HTAB\t";
@@ -253,7 +253,7 @@ public class DKIMSignerTest {
 
   @Test
   public void testSimpleBodyCannonic() {
-    DKIMSignOptions dkimOps = dkimOps().setBodyCanonic(MessageCanonic.SIMPLE);
+    DKIMSignOptions dkimOps = dkimOps().setBodyCanonAlgo(CanonicalizationAlgorithm.SIMPLE);
     DKIMSigner signer = new DKIMSigner(dkimOps, null);
 
     String body = "This is a Multiple Lines Text\n.Some lines start with one dot\n..Some" +
@@ -277,7 +277,7 @@ public class DKIMSignerTest {
 
   @Test
   public void testRelaxedBodyCannonic() {
-    DKIMSignOptions dkimOps = dkimOps().setBodyCanonic(MessageCanonic.RELAXED);
+    DKIMSignOptions dkimOps = dkimOps().setBodyCanonAlgo(CanonicalizationAlgorithm.RELAXED);
     DKIMSigner signer = new DKIMSigner(dkimOps, null);
 
     String body = "simple line";


### PR DESCRIPTION
Fixes: #139 

`MessageCanonic.java` was introduced from `4.0.0.milestone4`, so it should be fine to rename it before next milestone and ga.