### PR TITLE
Support Pipelining

### DIFF
--- a/src/main/asciidoc/dataobjects.adoc
+++ b/src/main/asciidoc/dataobjects.adoc
@@ -147,6 +147,9 @@ set the hostname to be used for HELO/EHLO and the Message-ID
 |[[password]]`@password`|`String`|+++
 Set the password for the login.
 +++
+|[[pipelining]]`@pipelining`|`Boolean`|+++
+Sets to enable/disable the pipelining capability if SMTP server supports it.
++++
 |[[port]]`@port`|`Number (int)`|+++
 Set the port of the smtp server.
 +++

--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -147,7 +147,6 @@ You can cache data from attachment's Stream to a temporary file by specifying a 
 `vertx.mail.attachment.cache.file` to `true` for large attachments. It will try to delete the temporary file
 after each send.
 
-
 == Mail-client data objects
 
 === MailMessage properties
@@ -213,6 +212,7 @@ The configuration has the following properties
 * `userAgent` String represents the Mail User Agent(MUA) name used to generate email boundaries for multipart emails and message-id, default is `vertxmail`.
 * `enableDKIM` boolean if true, the DKIM signing will be enabled if DKIM configurations are set as well, default is `false`.
 * `dkimSignOptions` List of `DKIMSignOptions` which are used to perform the DKIM sign.
+* `pipelining` enables pipelining if the SMTP server supports it. Default is `true`
 
 === MailResult object
 The MailResult object has the following members

--- a/src/main/java/io/vertx/ext/mail/impl/Capabilities.java
+++ b/src/main/java/io/vertx/ext/mail/impl/Capabilities.java
@@ -52,6 +52,11 @@ class Capabilities {
   private boolean capaStartTLS;
 
   /**
+   * if the server supports PIPELINING
+   */
+  private boolean capaPipelining;
+
+  /**
    * @return Set of Strings of capabilities
    */
   Set<String> getCapaAuth() {
@@ -63,6 +68,13 @@ class Capabilities {
    */
   int getSize() {
     return capaSize;
+  }
+
+  /**
+   * @return if the server supports PIPELINING
+   */
+  boolean isCapaPipelining() {
+    return capaPipelining;
   }
 
   /**
@@ -88,6 +100,9 @@ class Capabilities {
       if (c.equals("STARTTLS")) {
         capaStartTLS = true;
       }
+      if (c.equals("PIPELINING")) {
+        capaPipelining = true;
+      }
       if (c.startsWith("AUTH ")) {
         capaAuth = Utils.parseCapaAuth(c.substring(5));
       }
@@ -107,7 +122,7 @@ class Capabilities {
   /**
    * parse a multi-line EHLO reply string into a List of lines
    *
-   * @param message
+   * @param message the EHLO response message
    * @return List of lines
    */
   private List<String> parseEhlo(String message) {

--- a/src/main/java/io/vertx/ext/mail/impl/MailClientImpl.java
+++ b/src/main/java/io/vertx/ext/mail/impl/MailClientImpl.java
@@ -152,14 +152,14 @@ public class MailClientImpl implements MailClient {
       final EncodedPart encodedPart = encoder.encodeMail();
       final String messageId = encoder.getMessageID();
 
-      final SMTPSendMail sendMail = new SMTPSendMail(conn, email, config, encodedPart, messageId, sentResultHandler);
+      final SMTPSendMail sendMail = new SMTPSendMail(conn, email, config, encodedPart, messageId);
       if (dkimSigners.isEmpty()) {
-        sendMail.start();
+        sendMail.startMailTransaction(sentResultHandler);
       } else {
         // generate the DKIM header before start
         dkimFuture(context, encodedPart).onComplete(dkim -> context.runOnContext(h -> {
           if (dkim.succeeded()) {
-            sendMail.start();
+            sendMail.startMailTransaction(sentResultHandler);
           } else {
             sentResultHandler.handle(Future.failedFuture(dkim.cause()));
           }

--- a/src/test/java/io/vertx/ext/mail/HeloTest.java
+++ b/src/test/java/io/vertx/ext/mail/HeloTest.java
@@ -111,8 +111,7 @@ public class HeloTest extends SMTPTestDummy {
     smtpServer.setDialogue("220 example.com ESMTP",
       "EHLO",
       "250-example.com\n" +
-        "250-SIZE 48000000\n" +
-        "250 PIPELINING",
+        "250 SIZE 48000000",
       "MAIL FROM",
       "250 2.1.0 Ok",
       "RCPT TO",
@@ -153,8 +152,7 @@ public class HeloTest extends SMTPTestDummy {
     smtpServer.setDialogue("220 example.com ESMTP multiline",
       "EHLO",
       "250-example.com\n" +
-        "250-SIZE 48000000\n" +
-        "250 PIPELINING",
+        "250 SIZE 48000000",
       "MAIL FROM",
       "250 2.1.0 Ok",
       "RCPT TO",
@@ -192,8 +190,7 @@ public class HeloTest extends SMTPTestDummy {
         "220 this is supposed to confuse spammers",
       "EHLO",
       "250-example.com\n" +
-        "250-SIZE 48000000\n" +
-        "250 PIPELINING",
+        "250 SIZE 48000000",
       "MAIL FROM",
       "250 2.1.0 Ok",
       "RCPT TO",

--- a/src/test/java/io/vertx/ext/mail/MailAuthTest.java
+++ b/src/test/java/io/vertx/ext/mail/MailAuthTest.java
@@ -260,8 +260,7 @@ public class MailAuthTest extends SMTPTestDummy {
       "250-SIZE 35651584\n" +
       "250-8BITMIME\n" +
       "250-AUTH LOGIN PLAIN XOAUTH XOAUTH2\n" +
-      "250-ENHANCEDSTATUSCODES\n" +
-      "250 PIPELINING",
+      "250 ENHANCEDSTATUSCODES",
       "AUTH XOAUTH2 dXNlcj14eHgBYXV0aD1CZWFyZXIgeXl5AQE=",
       "235 2.7.0 Accepted",
       "MAIL FROM",
@@ -290,8 +289,7 @@ public class MailAuthTest extends SMTPTestDummy {
       "250-SIZE 35651584\n" +
       "250-8BITMIME\n" +
       "250-AUTH LOGIN PLAIN XOAUTH XOAUTH2\n" +
-      "250-ENHANCEDSTATUSCODES\n" +
-      "250 PIPELINING",
+      "250 ENHANCEDSTATUSCODES",
 
       "AUTH XOAUTH2 dXNlcj14eHgBYXV0aD1CZWFyZXIgeXl5AQE=",
 

--- a/src/test/java/io/vertx/ext/mail/MailConfigTest.java
+++ b/src/test/java/io/vertx/ext/mail/MailConfigTest.java
@@ -321,4 +321,12 @@ public class MailConfigTest {
     }
   }
 
+  @Test
+  public void testPipelining() {
+    MailConfig mailConfig = new MailConfig();
+    assertTrue(mailConfig.isPipelining());
+    mailConfig.setPipelining(false);
+    assertFalse(mailConfig.isPipelining());
+  }
+
 }

--- a/src/test/java/io/vertx/ext/mail/MailFromSizeTest.java
+++ b/src/test/java/io/vertx/ext/mail/MailFromSizeTest.java
@@ -37,8 +37,7 @@ public class MailFromSizeTest extends SMTPTestDummy {
         "220 example.com ESMTP",
         "EHLO",
         "250-example.com\n" +
-            "250-SIZE 1000000\n" +
-            "250 PIPELINING",
+            "250 SIZE 1000000",
         "^MAIL FROM:<[^>]+@[^>]+> SIZE=[0-9]+$",
         "250 2.1.0 Ok",
         "RCPT TO:",

--- a/src/test/java/io/vertx/ext/mail/MailPoolServerClosesTest.java
+++ b/src/test/java/io/vertx/ext/mail/MailPoolServerClosesTest.java
@@ -137,8 +137,7 @@ public class MailPoolServerClosesTest extends SMTPTestDummy {
       .setDialogue("220 example.com ESMTP",
       "EHLO",
       "250-example.com\n" +
-        "250-SIZE 1000000\n" +
-        "250 PIPELINING",
+        "250 SIZE 1000000",
       "MAIL FROM",
       "250 2.1.0 Ok",
       "RCPT TO",
@@ -195,8 +194,7 @@ public class MailPoolServerClosesTest extends SMTPTestDummy {
       .setDialogue("220 example.com ESMTP",
       "EHLO",
       "250-example.com\n" +
-        "250-SIZE 1000000\n" +
-        "250 PIPELINING",
+        "250 SIZE 1000000",
       "MAIL FROM",
       "250 2.1.0 Ok",
       "RCPT TO",
@@ -251,8 +249,7 @@ public class MailPoolServerClosesTest extends SMTPTestDummy {
     smtpServer.setDialogue("220 example.com ESMTP",
       "EHLO",
       "250-example.com\n" +
-        "250-SIZE 1000000\n" +
-        "250 PIPELINING",
+        "250 SIZE 1000000",
       "MAIL FROM",
       "250 2.1.0 Ok",
       "RCPT TO",

--- a/src/test/java/io/vertx/ext/mail/MailValidCertWrongHostTest.java
+++ b/src/test/java/io/vertx/ext/mail/MailValidCertWrongHostTest.java
@@ -59,15 +59,13 @@ public class MailValidCertWrongHostTest extends SMTPTestDummy {
         "EHLO",
         "250-example.com\n"
             + "250-SIZE 1000000\n"
-            + "250-STARTTLS\n"
-            + "250 PIPELINING",
+            + "250 STARTTLS",
         "STARTTLS",
         "220 2.0.0 Ready to start TLS",
         "EHLO",
         "250-example.com\n"
             + "250-SIZE 1000000\n"
-            + "250-STARTTLS\n"
-            + "250 PIPELINING",
+            + "250 STARTTLS",
         "MAIL FROM:",
         "250 2.1.0 Ok",
         "RCPT TO:",

--- a/src/test/java/io/vertx/ext/mail/impl/CapabilitiesTest.java
+++ b/src/test/java/io/vertx/ext/mail/impl/CapabilitiesTest.java
@@ -1,0 +1,48 @@
+/*
+ *  Copyright (c) 2011-2019 The original author or authors
+ *
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  and Apache License v2.0 which accompanies this distribution.
+ *
+ *       The Eclipse Public License is available at
+ *       http://www.eclipse.org/legal/epl-v10.html
+ *
+ *       The Apache License v2.0 is available at
+ *       http://www.opensource.org/licenses/apache2.0.php
+ *
+ *  You may elect to redistribute this code under either of these licenses.
+ */
+
+package io.vertx.ext.mail.impl;
+
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Tests SMTP Server's capabilities from message
+ *
+ * @author <a href="mailto:aoingl@gmail.com">Lin Gao</a>
+ */
+@RunWith(VertxUnitRunner.class)
+public class CapabilitiesTest {
+
+  @Test
+  public void testCapaFromMessage(TestContext testContext) {
+    String message = "250-localhost\n" +
+      "250-8BITMIME\n" +
+      "250-STARTTLS\n" +
+      "250-PIPELINING\n" +
+      "250-AUTH PLAIN\n" +
+      "250 Ok";
+    Capabilities capa = new Capabilities();
+    capa.parseCapabilities(message);
+    testContext.assertTrue(capa.isCapaPipelining());
+    testContext.assertTrue(capa.isStartTLS());
+    testContext.assertEquals(1, capa.getCapaAuth().size());
+    testContext.assertTrue(capa.getCapaAuth().iterator().next().equals("PLAIN"));
+  }
+
+}

--- a/src/test/java/io/vertx/ext/mail/impl/MailAuthChainTest.java
+++ b/src/test/java/io/vertx/ext/mail/impl/MailAuthChainTest.java
@@ -47,7 +47,6 @@ public class MailAuthChainTest extends SMTPTestDummy {
         "250-8BITMIME\n" +
         "250-AUTH LOGIN PLAIN XOAUTH2 PLAIN-CLIENTTOKEN OAUTHBEARER XOAUTH\n" +
         "250-ENHANCEDSTATUSCODES\n" +
-        "250-PIPELINING\n" +
         "250-CHUNKING\n" +
         "250 SMTPUTF8",
       "AUTH XOAUTH2 dXNlcj14eHgBYXV0aD1CZWFyZXIgeXl5AQE=",
@@ -83,7 +82,6 @@ public class MailAuthChainTest extends SMTPTestDummy {
           "250-8BITMIME\n" +
           "250-AUTH LOGIN PLAIN XOAUTH2 PLAIN-CLIENTTOKEN OAUTHBEARER XOAUTH\n" +
           "250-ENHANCEDSTATUSCODES\n" +
-          "250-PIPELINING\n" +
           "250-CHUNKING\n" +
           "250 SMTPUTF8",
         "AUTH LOGIN",
@@ -120,7 +118,6 @@ public class MailAuthChainTest extends SMTPTestDummy {
         "250-8BITMIME\n" +
         "250-AUTH LOGIN PLAIN XOAUTH2\n" +
         "250-ENHANCEDSTATUSCODES\n" +
-        "250-PIPELINING\n" +
         "250-CHUNKING\n" +
         "250 SMTPUTF8",
       "AUTH XOAUTH2 dXNlcj14eHgBYXV0aD1CZWFyZXIgeXl5AQE=",
@@ -161,7 +158,6 @@ public class MailAuthChainTest extends SMTPTestDummy {
         "250-8BITMIME\n" +
         "250-AUTH LOGIN PLAIN XOAUTH2\n" +
         "250-ENHANCEDSTATUSCODES\n" +
-        "250-PIPELINING\n" +
         "250-CHUNKING\n" +
         "250 SMTPUTF8",
       "AUTH LOGIN",
@@ -207,7 +203,6 @@ public class MailAuthChainTest extends SMTPTestDummy {
           "250-8BITMIME\n" +
           "250-AUTH LOGIN PLAIN XOAUTH2 PLAIN-CLIENTTOKEN OAUTHBEARER XOAUTH\n" +
           "250-ENHANCEDSTATUSCODES\n" +
-          "250-PIPELINING\n" +
           "250-CHUNKING\n" +
           "250 SMTPUTF8",
         "AUTH PLAIN AHh4eAB5eXk=",

--- a/src/test/java/io/vertx/ext/mail/impl/MailPipeliningTest.java
+++ b/src/test/java/io/vertx/ext/mail/impl/MailPipeliningTest.java
@@ -1,0 +1,265 @@
+/*
+ *  Copyright (c) 2011-2019 The original author or authors
+ *
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  and Apache License v2.0 which accompanies this distribution.
+ *
+ *       The Eclipse Public License is available at
+ *       http://www.eclipse.org/legal/epl-v10.html
+ *
+ *       The Apache License v2.0 is available at
+ *       http://www.opensource.org/licenses/apache2.0.php
+ *
+ *  You may elect to redistribute this code under either of these licenses.
+ */
+
+package io.vertx.ext.mail.impl;
+
+import io.vertx.ext.mail.MailClient;
+import io.vertx.ext.mail.MailConfig;
+import io.vertx.ext.mail.MailMessage;
+import io.vertx.ext.mail.SMTPTestDummy;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.Arrays;
+
+/**
+ * Tests SMTP Pipelining
+ *
+ * @author <a href="mailto:aoingl@gmail.com">Lin Gao</a>
+ */
+@RunWith(VertxUnitRunner.class)
+public class MailPipeliningTest extends SMTPTestDummy {
+
+  @Test
+  public void pipeLiningSuccessTest(TestContext testContext) {
+    this.testContext = testContext;
+    final String[][] dialogue = {
+      {"220 smtp.gmail.com ESMTP o8sm3958210pjs.6 - gsmtp"},
+      {"EHLO"},
+      {"250-smtp.gmail.com at your service, [209.132.188.80]\n" +
+        "250-AUTH LOGIN PLAIN\n" +
+        "250 PIPELINING"},
+      {"AUTH LOGIN"},
+      {"334 VXNlcm5hbWU6"},
+      {"eHh4"},
+      {"334 UGFzc3dvcmQ6"},
+      {"eXl5"},
+      {"250 2.1.0 Ok"},
+      {"MAIL FROM", "RCPT TO", "DATA"},
+      {"250 2.1.0 mail from Ok", "250 2.1.0 rcpto Ok", "354 End data with <CR><LF>.<CR><LF>"},
+      {"250 2.0.0 Ok: queued as ABCD"},
+      {"QUIT"},
+      {"221 2.0.0 Bye"}
+    };
+    smtpServer.setDialogueArray(dialogue);
+    testSuccess(mailClientLogin(), exampleMessage());
+  }
+
+  @Test
+  public void pipeLiningMultipleRCPTsTest(TestContext testContext) {
+    this.testContext = testContext;
+    final String[][] dialogue = {
+      {"220 smtp.gmail.com ESMTP o8sm3958210pjs.6 - gsmtp"},
+      {"EHLO"},
+      {"250-smtp.gmail.com at your service, [209.132.188.80]\n" +
+        "250-AUTH LOGIN PLAIN\n" +
+        "250 PIPELINING"},
+      {"AUTH LOGIN"},
+      {"334 VXNlcm5hbWU6"},
+      {"eHh4"},
+      {"334 UGFzc3dvcmQ6"},
+      {"eXl5"},
+      {"250 2.1.0 Ok"},
+      {"MAIL FROM", "RCPT TO", "RCPT TO", "DATA"},
+      {"250 2.1.0 Ok", "250 2.1.0 Ok", "250 2.1.0 Ok", "354 End data with <CR><LF>.<CR><LF>"},
+      {"250 2.0.0 Ok: queued as ABCD"},
+      {"QUIT"},
+      {"221 2.0.0 Bye"}
+    };
+    smtpServer.setDialogueArray(dialogue);
+    MailMessage message = exampleMessage().setTo(Arrays.asList("userA@example.com", "userB@example.com"));
+    testSuccess(mailClientLogin(), message);
+  }
+
+  /**
+   * Some rcpt-tos are rejected, it fails the mail send.
+   */
+  @Test
+  public void pipeLiningMultipleRCPTsSomeRejectedTest(TestContext testContext) {
+    this.testContext = testContext;
+    final String[][] dialogue = {
+      {"220 smtp.gmail.com ESMTP o8sm3958210pjs.6 - gsmtp"},
+      {"EHLO"},
+      {"250-smtp.gmail.com at your service, [209.132.188.80]\n" +
+        "250-AUTH LOGIN PLAIN\n" +
+        "250 PIPELINING"},
+      {"AUTH LOGIN"},
+      {"334 VXNlcm5hbWU6"},
+      {"eHh4"},
+      {"334 UGFzc3dvcmQ6"},
+      {"eXl5"},
+      {"250 2.1.0 Ok"},
+      {"MAIL FROM", "RCPT TO", "RCPT TO", "DATA"},
+      {"250 2.1.0 Ok", "250 2.1.0 Ok", "550 5.1.1 Unknown user: userB@example.com", "354 End data with <CR><LF>.<CR><LF>"},
+      {"250 2.0.0 Ok: queued as ABCD"},
+      {"QUIT"},
+      {"221 2.0.0 Bye"}
+    };
+    smtpServer.setDialogueArray(dialogue);
+    MailMessage message = exampleMessage().setTo(Arrays.asList("userA@example.com", "userB@example.com"));
+    MailClient mailClient = mailClientLogin();
+    mailClient.sendMail(message, testContext.asyncAssertFailure(t -> {
+        testContext.assertTrue(t.getMessage().contains("550 5.1.1 Unknown user: userB@example.com"));
+        mailClient.close();
+      })
+    );
+  }
+
+  /**
+   * Some rcpt-to are rejected, but MailConfig allows such failures
+   * In this case, recipients list in MailResult are less than specified in MailMessage.
+   */
+  @Test
+  public void pipeLiningMultipleRCPTsSomeRejectedAllowedTest(TestContext testContext) {
+    this.testContext = testContext;
+    final String[][] dialogue = {
+      {"220 smtp.gmail.com ESMTP o8sm3958210pjs.6 - gsmtp"},
+      {"EHLO"},
+      {"250-smtp.gmail.com at your service, [209.132.188.80]\n" +
+        "250-AUTH LOGIN PLAIN\n" +
+        "250 PIPELINING"},
+      {"AUTH LOGIN"},
+      {"334 VXNlcm5hbWU6"},
+      {"eHh4"},
+      {"334 UGFzc3dvcmQ6"},
+      {"eXl5"},
+      {"250 2.1.0 Ok"},
+      {"MAIL FROM", "RCPT TO", "RCPT TO", "DATA"},
+      {"250 2.1.0 Ok", "250 2.1.0 Ok", "550 5.1.1 Unknown user: userB@example.com", "354 End data with <CR><LF>.<CR><LF>"},
+      {"250 2.0.0 Ok: queued as ABCD"},
+      {"QUIT"},
+      {"221 2.0.0 Bye"}
+    };
+    smtpServer.setDialogueArray(dialogue);
+    MailMessage message = exampleMessage().setTo(Arrays.asList("userA@example.com", "userB@example.com"));
+    MailConfig mailConfig = configLogin().setAllowRcptErrors(true);
+    MailClient mailClient = MailClient.createShared(vertx, mailConfig);
+    mailClient.sendMail(message, testContext.asyncAssertSuccess(mr -> {
+      testContext.assertTrue(mr.getRecipients().contains("userA@example.com"));
+      testContext.assertFalse(mr.getRecipients().contains("userB@example.com"));
+      mailClient.close();
+    }));
+  }
+
+  /**
+   * All rcpts are rejected, but DATA command response is OK, send dot only in this case
+   */
+  @Test
+  public void pipeLiningMultipleRCPTsAllRejectedDataOKTest(TestContext testContext) {
+    this.testContext = testContext;
+    final String[][] dialogue = {
+      {"220 smtp.gmail.com ESMTP o8sm3958210pjs.6 - gsmtp"},
+      {"EHLO"},
+      {"250-smtp.gmail.com at your service, [209.132.188.80]\n" +
+        "250-AUTH LOGIN PLAIN\n" +
+        "250 PIPELINING"},
+      {"AUTH LOGIN"},
+      {"334 VXNlcm5hbWU6"},
+      {"eHh4"},
+      {"334 UGFzc3dvcmQ6"},
+      {"eXl5"},
+      {"250 2.1.0 Ok"},
+      {"MAIL FROM", "RCPT TO", "RCPT TO", "DATA"},
+      {"250 2.1.0 Ok", "550 5.1.1 Unknown user: userA@example.com", "550 5.1.1 Unknown user: userB@example.com", "354 End data with <CR><LF>.<CR><LF>"},
+      {"250 2.0.0 Ok: queued as ABCD"},
+      {"QUIT"},
+      {"554 no valid recipients"} // QUIT failures are ignored.
+    };
+    smtpServer.setDialogueArray(dialogue);
+    MailMessage message = exampleMessage().setTo(Arrays.asList("userA@example.com", "userB@example.com"));
+    MailConfig mailConfig = configLogin().setAllowRcptErrors(true);
+    MailClient mailClient = MailClient.createShared(vertx, mailConfig);
+    mailClient.sendMail(message, testContext.asyncAssertSuccess(mr -> {
+      testContext.assertFalse(mr.getRecipients().contains("userA@example.com"));
+      testContext.assertFalse(mr.getRecipients().contains("userB@example.com"));
+      // only dot got sent, but no way to test it in smtp server.
+      mailClient.close();
+    }));
+  }
+
+  /**
+   * All rcpts are rejected, but DATA command response is fail, just close the mail transaction
+   */
+  @Test
+  public void pipeLiningMultipleRCPTsAllRejectedDataFailTest(TestContext testContext) {
+    this.testContext = testContext;
+    final String[][] dialogue = {
+      {"220 smtp.gmail.com ESMTP o8sm3958210pjs.6 - gsmtp"},
+      {"EHLO"},
+      {"250-smtp.gmail.com at your service, [209.132.188.80]\n" +
+        "250-AUTH LOGIN PLAIN\n" +
+        "250 PIPELINING"},
+      {"AUTH LOGIN"},
+      {"334 VXNlcm5hbWU6"},
+      {"eHh4"},
+      {"334 UGFzc3dvcmQ6"},
+      {"eXl5"},
+      {"250 2.1.0 Ok"},
+      {"MAIL FROM", "RCPT TO", "RCPT TO", "DATA"},
+      {"250 2.1.0 Ok", "550 5.1.1 Unknown user: userA@example.com", "550 5.1.1 Unknown user: userB@example.com", "554 no valid recipients given"},
+      {"250 2.0.0 Ok: queued as ABCD"},
+      {"QUIT"},
+      {"221 2.0.0 Bye"}
+    };
+    smtpServer.setDialogueArray(dialogue);
+    MailMessage message = exampleMessage().setTo(Arrays.asList("userA@example.com", "userB@example.com"));
+    MailConfig mailConfig = configLogin().setAllowRcptErrors(true);
+    MailClient mailClient = MailClient.createShared(vertx, mailConfig);
+    mailClient.sendMail(message, testContext.asyncAssertFailure(t -> {
+      testContext.assertTrue(t.getMessage().contains("554 no valid recipients given"));
+      mailClient.close();
+    }));
+  }
+
+  /**
+   * Test the case of multi-lines responses in the group commands.
+   */
+  @Test
+  public void pipeLiningMultilineResponseTest(TestContext testContext) {
+    this.testContext = testContext;
+    final String[][] dialogue = {
+      {"220 smtp.gmail.com ESMTP o8sm3958210pjs.6 - gsmtp"},
+      {"EHLO"},
+      {"250-smtp.gmail.com at your service, [209.132.188.80]\n" +
+        "250-AUTH LOGIN PLAIN\n" +
+        "250 PIPELINING"},
+      {"AUTH LOGIN"},
+      {"334 VXNlcm5hbWU6"},
+      {"eHh4"},
+      {"334 UGFzc3dvcmQ6"},
+      {"eXl5"},
+      {"250 2.1.0 Ok"},
+      {"MAIL FROM", "RCPT TO", "RCPT TO", "DATA"},
+      {"250 2.1.0 Ok", "250-2.1.0 Ok\n" + "250 2.1.1 OK", "250 2.1.0 Ok", "354 End data with <CR><LF>.<CR><LF>"},
+      {"250 2.0.0 Ok: queued as ABCD"},
+      {"QUIT"},
+      {"221 2.0.0 Bye"}
+    };
+    smtpServer.setDialogueArray(dialogue);
+    MailMessage message = exampleMessage().setTo(Arrays.asList("userA@example.com", "userB@example.com"));
+    MailConfig mailConfig = configLogin().setAllowRcptErrors(true);
+    MailClient mailClient = MailClient.createShared(vertx, mailConfig);
+    mailClient.sendMail(message, testContext.asyncAssertSuccess(mr -> {
+      testContext.assertTrue(mr.getRecipients().contains("userA@example.com"));
+      testContext.assertTrue(mr.getRecipients().contains("userB@example.com"));
+      mailClient.close();
+    }));
+
+  }
+
+}

--- a/src/test/java/io/vertx/ext/mail/impl/MultilineParserTest.java
+++ b/src/test/java/io/vertx/ext/mail/impl/MultilineParserTest.java
@@ -1,0 +1,281 @@
+/*
+ *  Copyright (c) 2011-2019 The original author or authors
+ *
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  and Apache License v2.0 which accompanies this distribution.
+ *
+ *       The Eclipse Public License is available at
+ *       http://www.eclipse.org/legal/epl-v10.html
+ *
+ *       The Apache License v2.0 is available at
+ *       http://www.opensource.org/licenses/apache2.0.php
+ *
+ *  You may elect to redistribute this code under either of these licenses.
+ */
+
+package io.vertx.ext.mail.impl;
+
+import io.vertx.core.Handler;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.impl.logging.Logger;
+import io.vertx.core.impl.logging.LoggerFactory;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Tests MultilineParser.
+ *
+ * @author <a href="mailto:aoingl@gmail.com">Lin Gao</a>
+ */
+@RunWith(VertxUnitRunner.class)
+public class MultilineParserTest {
+
+  private static final Logger logger = LoggerFactory.getLogger(MultilineParserTest.class);
+
+  /**
+   * Tests one response with one line
+   */
+  @Test
+  public void testOneResponseOneLine(TestContext testContext) {
+    Async async = testContext.async(2);
+    final String ehloBanner = "220 hello from smtp server";
+    final String oneLineResp = "250 2.1.0 OK";
+    final AtomicBoolean init = new AtomicBoolean(false);
+    Handler<Buffer> dataHandler = b -> {
+      if (!init.get()) {
+        testContext.assertEquals(ehloBanner, b.toString());
+        async.countDown();
+      } else {
+        String message = b.toString();
+        testContext.assertTrue(StatusCode.isStatusOk(message));
+        testContext.assertEquals(oneLineResp, message);
+        async.countDown();
+      }
+    };
+    MultilineParser multilineParser = new MultilineParser(dataHandler);
+    multilineParser.setExpected(1);
+    // simulate the ehlo banner on connection
+    multilineParser.handle(Buffer.buffer(ehloBanner + "\r\n"));
+    init.set(true);
+    multilineParser.handle(Buffer.buffer(oneLineResp + "\r\n"));
+  }
+
+  /**
+   * Tests one response with multiple lines.
+   *
+   * Capabilities declared by SMTP server are good example here.
+   */
+  @Test
+  public void testOneResponseMultiLines(TestContext testContext) {
+    Async async = testContext.async(2);
+    final String ehloBanner = "220 hello from smtp server";
+    final AtomicBoolean init = new AtomicBoolean(false);
+    final String capaMessage = "250-smtp.gmail.com at your service, [209.132.188.80]\n" +
+      "250-AUTH LOGIN PLAIN\n" +
+      "250 PIPELINING";
+    Handler<Buffer> dataHandler = b -> {
+      if (!init.get()) {
+        testContext.assertEquals(ehloBanner, b.toString());
+        async.countDown();
+      } else {
+        String message = b.toString();
+        testContext.assertTrue(StatusCode.isStatusOk(message));
+        testContext.assertEquals(capaMessage, message);
+        Capabilities capa = new Capabilities();
+        capa.parseCapabilities(message);
+        testContext.assertTrue(capa.isCapaPipelining());
+        testContext.assertFalse(capa.isStartTLS());
+        testContext.assertEquals(2, capa.getCapaAuth().size());
+        testContext.assertTrue(capa.getCapaAuth().contains("LOGIN"));
+        testContext.assertTrue(capa.getCapaAuth().contains("PLAIN"));
+        async.countDown();
+      }
+    };
+    MultilineParser multilineParser = new MultilineParser(dataHandler);
+    multilineParser.setExpected(1);
+    // simulate the ehlo banner on connection
+    multilineParser.handle(Buffer.buffer(ehloBanner + "\r\n"));
+    init.set(true);
+    multilineParser.handle(Buffer.buffer(capaMessage + "\r\n"));
+  }
+
+  /**
+   * Tests one response with multiple lines with crlf ends for each line
+   *
+   * Capabilities declared by SMTP server are good example here.
+   */
+  @Test
+  public void testOneResponseMultiLinesEndwithCRLF(TestContext testContext) {
+    Async async = testContext.async(2);
+    final String ehloBanner = "220 hello from smtp server";
+    final AtomicBoolean init = new AtomicBoolean(false);
+    final String capaMessage = "250-smtp.gmail.com at your service, [209.132.188.80]\r\n" +
+      "250-AUTH LOGIN PLAIN\r\n" +
+      "250 PIPELINING";
+    final String expected = "250-smtp.gmail.com at your service, [209.132.188.80]\n" +
+      "250-AUTH LOGIN PLAIN\n" +
+      "250 PIPELINING";
+    Handler<Buffer> dataHandler = b -> {
+      if (!init.get()) {
+        testContext.assertEquals(ehloBanner, b.toString());
+        async.countDown();
+      } else {
+        String message = b.toString();
+        testContext.assertTrue(StatusCode.isStatusOk(message));
+        testContext.assertEquals(expected, message);
+        Capabilities capa = new Capabilities();
+        capa.parseCapabilities(message);
+        testContext.assertTrue(capa.isCapaPipelining());
+        testContext.assertFalse(capa.isStartTLS());
+        testContext.assertEquals(2, capa.getCapaAuth().size());
+        testContext.assertTrue(capa.getCapaAuth().contains("LOGIN"));
+        testContext.assertTrue(capa.getCapaAuth().contains("PLAIN"));
+        async.countDown();
+      }
+    };
+    MultilineParser multilineParser = new MultilineParser(dataHandler);
+    multilineParser.setExpected(1);
+    // simulate the ehlo banner on connection
+    multilineParser.handle(Buffer.buffer(ehloBanner + "\r\n"));
+    init.set(true);
+    multilineParser.handle(Buffer.buffer(capaMessage + "\r\n"));
+  }
+
+  /**
+   * Tests multi responses, each response has one line
+   */
+  @Test
+  public void testMultiResponseMultiLines(TestContext testContext) {
+    Async async = testContext.async(2);
+    final String ehloBanner = "220 hello from smtp server";
+    final AtomicBoolean init = new AtomicBoolean(false);
+    final String multilines = "250 2.1.0 OK1\r\n" +
+      "250 2.1.1 OK2\r\n" +
+      "250 2.1.2 OK3";
+    Handler<Buffer> dataHandler = b -> {
+      if (!init.get()) {
+        testContext.assertEquals(ehloBanner, b.toString());
+        async.countDown();
+      } else {
+        String message = b.toString();
+        testContext.assertTrue(StatusCode.isStatusOk(message));
+        testContext.assertEquals(multilines, message);
+        String[] lines = message.split("\r\n");
+        for (String l: lines) {
+          System.out.println("Line:" + l + ":-");
+        }
+        testContext.assertEquals(3, lines.length);
+        testContext.assertEquals("250 2.1.0 OK1", lines[0]);
+        testContext.assertEquals("250 2.1.1 OK2", lines[1]);
+        testContext.assertEquals("250 2.1.2 OK3", lines[2]);
+        async.countDown();
+      }
+    };
+    MultilineParser multilineParser = new MultilineParser(dataHandler);
+    multilineParser.setExpected(1);
+    // simulate the ehlo banner on connection
+    multilineParser.handle(Buffer.buffer(ehloBanner + "\r\n"));
+    init.set(true);
+    multilineParser.setExpected(3);
+    multilineParser.handle(Buffer.buffer(multilines + "\r\n"));
+  }
+
+  /**
+   * Tests multi responses, each response has multiple lines
+   */
+  @Test
+  public void testMultiResponseMultiLinesMore(TestContext testContext) {
+    Async async = testContext.async(2);
+    final String ehloBanner = "220 hello from smtp server";
+    final AtomicBoolean init = new AtomicBoolean(false);
+    final String multilinesWithLF = "250-2.1.0 OK1\n250 2.1.0.1 OK1.1\r\n" +
+      "250 2.1.1 OK2\r\n" +
+      "250 2.1.2 OK3";
+    Handler<Buffer> dataHandler = b -> {
+      if (!init.get()) {
+        testContext.assertEquals(ehloBanner, b.toString());
+        async.countDown();
+      } else {
+        String message = b.toString();
+        testContext.assertTrue(StatusCode.isStatusOk(message));
+        testContext.assertEquals(multilinesWithLF, message);
+        String[] lines = message.split("\r\n");
+        testContext.assertEquals(3, lines.length);
+        testContext.assertEquals("250-2.1.0 OK1\n250 2.1.0.1 OK1.1", lines[0]);
+        testContext.assertEquals("250 2.1.1 OK2", lines[1]);
+        testContext.assertEquals("250 2.1.2 OK3", lines[2]);
+        async.countDown();
+      }
+    };
+    MultilineParser multilineParser = new MultilineParser(dataHandler);
+    multilineParser.setExpected(1);
+    // simulate the ehlo banner on connection
+    multilineParser.handle(Buffer.buffer(ehloBanner + "\r\n"));
+    init.set(true);
+    multilineParser.setExpected(3);
+    multilineParser.handle(Buffer.buffer(multilinesWithLF + "\r\n"));
+  }
+
+
+  /**
+   * Tests multi responses, each response has multiple lines with crlf ended for each line
+   */
+  @Test
+  public void testMultiResponseMultiLinesEndswithCRLFMore(TestContext testContext) {
+    Async async = testContext.async(2);
+    final String ehloBanner = "220 hello from smtp server";
+    final AtomicBoolean init = new AtomicBoolean(false);
+    final String multilinesWithLF = "250-2.1.0 OK1\r\n250 2.1.0.1 OK1.1\r\n" +
+      "250 2.1.1 OK2\r\n" +
+      "250 2.1.2 OK3";
+    final String expected = "250-2.1.0 OK1\n250 2.1.0.1 OK1.1\r\n" +
+      "250 2.1.1 OK2\r\n" +
+      "250 2.1.2 OK3";
+    Handler<Buffer> dataHandler = b -> {
+      if (!init.get()) {
+        testContext.assertEquals(ehloBanner, b.toString());
+        async.countDown();
+      } else {
+        String message = b.toString();
+        testContext.assertTrue(StatusCode.isStatusOk(message));
+        testContext.assertEquals(expected, message);
+        String[] lines = message.split("\r\n");
+        testContext.assertEquals(3, lines.length);
+        testContext.assertEquals("250-2.1.0 OK1\n250 2.1.0.1 OK1.1", lines[0]);
+        testContext.assertEquals("250 2.1.1 OK2", lines[1]);
+        testContext.assertEquals("250 2.1.2 OK3", lines[2]);
+        async.countDown();
+      }
+    };
+    MultilineParser multilineParser = new MultilineParser(dataHandler);
+    multilineParser.setExpected(1);
+    // simulate the ehlo banner on connection
+    multilineParser.handle(Buffer.buffer(ehloBanner + "\r\n"));
+    init.set(true);
+    multilineParser.setExpected(3);
+    multilineParser.handle(Buffer.buffer(multilinesWithLF + "\r\n"));
+  }
+
+  @Test
+  public void testLastLine(TestContext testContext) {
+    MultilineParser multilineParser = new MultilineParser(b -> logger.debug(b.toString()));
+    testContext.assertTrue(multilineParser.isFinalLine(Buffer.buffer("250 welcome OK")));
+    testContext.assertFalse(multilineParser.isFinalLine(Buffer.buffer("250-welcome OK")));
+
+    testContext.assertTrue(multilineParser.isFinalLine(Buffer.buffer("250-welcome OK\r\n250 2.1.0 OK")));
+    testContext.assertTrue(multilineParser.isFinalLine(Buffer.buffer("250 welcome OK\n250 2.1.0 OK")));
+
+    testContext.assertFalse(multilineParser.isFinalLine(Buffer.buffer("250-welcome OK\n250-2.1.0 OK")));
+    testContext.assertFalse(multilineParser.isFinalLine(Buffer.buffer("250-welcome OK\r\n250-2.1.0 OK")));
+
+    testContext.assertTrue(multilineParser.isFinalLine(Buffer.buffer("250-welcome OK\n250-2.1.0 OK\n250 2.1.1 OK")));
+    testContext.assertTrue(multilineParser.isFinalLine(Buffer.buffer("250-welcome OK\r\n250-2.1.0 OK\r\n250 2.1.1 OK")));
+
+  }
+}

--- a/src/test/java/io/vertx/ext/mail/impl/SMTPConnectionPoolDummySMTPTest.java
+++ b/src/test/java/io/vertx/ext/mail/impl/SMTPConnectionPoolDummySMTPTest.java
@@ -52,8 +52,7 @@ public class SMTPConnectionPoolDummySMTPTest extends SMTPTestDummy {
     smtpServer.setDialogue("220 example.com ESMTP",
         "EHLO",
         "250-example.com\n" +
-          "250-SIZE 1000000\n" +
-          "250 PIPELINING",
+          "250 SIZE 1000000",
         "MAIL FROM:",
         "250 2.1.0 Ok",
         "RCPT TO:",


### PR DESCRIPTION
* Introduce pipelining in MailConfig
* futurize the SMTPSendMail implementation to adopt new extensions easier
* Fixed tests which has PIPELINING extension declared
* Added related tests

Motivation:

Fixes: #143 

This PR added support of `SMTP Pipelining` into the vertx-mail-client, so that it will reduce round-trips when SMTP server support `Pipelining`. It also provides the option to switch back to not using the `Pipelining`.
