### PR TITLE
[Issue-150] Calling "close" on MailClient which was only ever used fo…

### DIFF
--- a/src/main/java/io/vertx/ext/mail/impl/SMTPConnectionPool.java
+++ b/src/main/java/io/vertx/ext/mail/impl/SMTPConnectionPool.java
@@ -130,6 +130,10 @@ class SMTPConnectionPool implements ConnectionLifeCycleListener {
     }
   }
 
+  NetClient getNetClient() {
+    return this.netClient;
+  }
+
   // Private methods
 
   private synchronized void getConnection0(Handler<AsyncResult<SMTPConnection>> handler) {
@@ -214,6 +218,7 @@ class SMTPConnectionPool implements ConnectionLifeCycleListener {
         }
       }
     } else {
+      this.netClient.close();
       if (closeFinishedHandler != null) {
         closeFinishedHandler.handle(null);
       }

--- a/src/test/java/io/vertx/ext/mail/impl/MailClientCloseTest.java
+++ b/src/test/java/io/vertx/ext/mail/impl/MailClientCloseTest.java
@@ -1,0 +1,74 @@
+/*
+ *  Copyright (c) 2011-2020 The original author or authors
+ *
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  and Apache License v2.0 which accompanies this distribution.
+ *
+ *       The Eclipse Public License is available at
+ *       http://www.eclipse.org/legal/epl-v10.html
+ *
+ *       The Apache License v2.0 is available at
+ *       http://www.opensource.org/licenses/apache2.0.php
+ *
+ *  You may elect to redistribute this code under either of these licenses.
+ */
+
+package io.vertx.ext.mail.impl;
+
+import io.vertx.ext.mail.LoginOption;
+import io.vertx.ext.mail.MailClient;
+import io.vertx.ext.mail.MailConfig;
+import io.vertx.ext.mail.SMTPTestDummy;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Tests MailClient close cases.
+ *
+ * @author <a href="mailto:aoingl@gmail.com">Lin Gao</a>
+ */
+@RunWith(VertxUnitRunner.class)
+public class MailClientCloseTest extends SMTPTestDummy {
+
+  /**
+   * Test the case that when MailClient is closed after some time when all connections failed with wrong credentials,
+   * the NetClient in the SMTPConnectionPool should be closed as well.
+   */
+  @Test
+  public void testNetClientClosedWhenMailClientClosed(TestContext testContext) {
+    smtpServer.setDialogue(
+      "220 smtp.gmail.com ESMTP o8sm3958210pjs.6 - gsmtp",
+      "EHLO",
+      "250-smtp.gmail.com at your service, [209.132.188.80]\n" +
+        "250-AUTH LOGIN\n" +
+        "250 SMTPUTF8",
+      "AUTH LOGIN",
+      "334 VXNlcm5hbWU6",
+      "eHh4",
+      "334 UGFzc3dvcmQ6",
+      "eXl5",
+      "435 4.7.8 Error: authentication failed: authentication failure",
+      "QUIT",
+      "221 2.0.0 Bye"
+    );
+    MailConfig config = configLogin();
+    MailClientImpl mailClient = (MailClientImpl)MailClient.create(vertx, config);
+    Async async = testContext.async();
+    mailClient.sendMail(exampleMessage(), testContext.asyncAssertFailure(t1 -> vertx.setTimer(100, r -> {
+      mailClient.close();
+      try {
+        mailClient.getConnectionPool().getNetClient()
+          .connect(config.getPort(), config.getHostname(), v -> {});
+        fail("SHOULD NOT HERE !");
+      } catch (IllegalStateException e) {
+        assertTrue(e.getMessage().contains("Client is closed"));
+        async.complete();
+      }
+    })));
+  }
+
+}


### PR DESCRIPTION
…r failed connection attempts does not call close on underlying NetClientImpl

Motivation:

Fixes: #150 to `3.9` branch

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
