### PR TITLE
[ISSUE-125] Make sure the callback handler is always called in caller context

### DIFF
--- a/src/test/java/io/vertx/ext/mail/impl/MailSendContextTest.java
+++ b/src/test/java/io/vertx/ext/mail/impl/MailSendContextTest.java
@@ -1,0 +1,93 @@
+/*
+ *  Copyright (c) 2011-2020 The original author or authors
+ *
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  and Apache License v2.0 which accompanies this distribution.
+ *
+ *       The Eclipse Public License is available at
+ *       http://www.eclipse.org/legal/epl-v10.html
+ *
+ *       The Apache License v2.0 is available at
+ *       http://www.opensource.org/licenses/apache2.0.php
+ *
+ *  You may elect to redistribute this code under either of these licenses.
+ */
+
+package io.vertx.ext.mail.impl;
+
+import io.vertx.core.AbstractVerticle;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
+import io.vertx.core.impl.logging.Logger;
+import io.vertx.core.impl.logging.LoggerFactory;
+import io.vertx.ext.mail.MailClient;
+import io.vertx.ext.mail.SMTPTestWiser;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Test that context on which the MailClient executes.
+ *
+ * @author <a href="mailto:aoingl@gmail.com">Lin Gao</a>
+ */
+@RunWith(VertxUnitRunner.class)
+public class MailSendContextTest extends SMTPTestWiser {
+
+  private static final Logger log = LoggerFactory.getLogger(MailSendContextTest.class);
+
+  private class VerticleA extends AbstractVerticle {
+    MailClient mailClientA;
+    @Override
+    public void start(Promise<Void> startPromise) {
+      mailClientA = MailClient.create(vertx, configLogin());
+      mailClientA.sendMail(exampleMessage(), r -> {
+        assertTrue(r.succeeded());
+        assertEquals(Vertx.currentContext(), context);
+        // deploy Verticle B
+        VerticleB verticleB = new VerticleB();
+        vertx.deployVerticle(verticleB, dr -> {
+          assertTrue(dr.succeeded());
+          assertEquals(Vertx.currentContext(), context);
+          assertNotNull(verticleB.mailClientB);
+          verticleB.mailClientB.sendMail(exampleMessage(), sr -> {
+            assertTrue(sr.succeeded());
+            assertEquals(Vertx.currentContext(), context);
+            startPromise.complete();
+          });
+        });
+      });
+    }
+    @Override
+    public void stop() throws Exception {
+      mailClientA.close();
+    }
+  }
+
+  private class VerticleB extends AbstractVerticle {
+    MailClient mailClientB;
+    @Override
+    public void start(Promise<Void> startPromise) {
+      mailClientB = MailClient.create(vertx, configLogin());
+      mailClientB.sendMail(exampleMessage(), sr -> {
+        assertTrue(sr.succeeded());
+        assertEquals(Vertx.currentContext(), context);
+        startPromise.complete();
+      });
+    }
+    @Override
+    public void stop() throws Exception {
+      mailClientB.close();
+    }
+  }
+
+  @Test
+  public void sendMailDifferentContext(TestContext testContext) {
+    VerticleA verticleA = new VerticleA();
+    log.debug("Deploy VerticleA");
+    vertx.deployVerticle(verticleA).onComplete(testContext.asyncAssertSuccess());
+  }
+
+}


### PR DESCRIPTION
Motivation:

Fixes #125 

Looks like that current implementation already makes sure that [the call back handler is always called in the caller context](https://github.com/vert-x3/vertx-mail-client/blob/15d9c72c91fdffcb0426fa5cecc63c1014966359/src/main/java/io/vertx/ext/mail/impl/MailClientImpl.java#L202), but without test to guarantee that, this PR added a test only to make sure it won't break the context model in the future development.
