### PR TITLE
[ISSUE-161] Format change between Vert.x 3 and 4

### DIFF
--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -213,6 +213,7 @@ The configuration has the following properties
 * `enableDKIM` boolean if true, the DKIM signing will be enabled if DKIM configurations are set as well, default is `false`.
 * `dkimSignOptions` List of `DKIMSignOptions` which are used to perform the DKIM sign.
 * `pipelining` enables pipelining if the SMTP server supports it. Default is `true`
+* `multiPartOnly` boolean, if encode mail messages as multipart only or not. Default is `false`
 
 === MailResult object
 The MailResult object has the following members

--- a/src/main/java/io/vertx/ext/mail/MailConfig.java
+++ b/src/main/java/io/vertx/ext/mail/MailConfig.java
@@ -57,6 +57,7 @@ public class MailConfig extends NetClientOptions {
   private static final boolean DEFAULT_ENABLE_DKIM = false;
   public static final String DEFAULT_USER_AGENT = "vertxmail";
   public static final boolean DEFAULT_ENABLE_PIPELINING = true;
+  public static final boolean DEFAULT_MULTI_PART_ONLY = false;
 
   private String hostname = DEFAULT_HOST;
   private int port = DEFAULT_PORT;
@@ -74,6 +75,7 @@ public class MailConfig extends NetClientOptions {
   private boolean enableDKIM = DEFAULT_ENABLE_DKIM;
   private List<DKIMSignOptions> dkimSignOptions;
   private boolean pipelining = DEFAULT_ENABLE_PIPELINING;
+  private boolean multiPartOnly = DEFAULT_MULTI_PART_ONLY;
 
   // https://tools.ietf.org/html/rfc5322#section-3.2.3, atext
   private static final Pattern A_TEXT_PATTERN = Pattern.compile("[a-zA-Z0-9!#$%&'*+-/=?^_`{|}~ ]+");
@@ -146,6 +148,7 @@ public class MailConfig extends NetClientOptions {
       dkimSignOptions = other.dkimSignOptions.stream().map(DKIMSignOptions::new).collect(Collectors.toList());
     }
     pipelining = other.pipelining;
+    multiPartOnly = other.multiPartOnly;
   }
 
   /**
@@ -194,6 +197,7 @@ public class MailConfig extends NetClientOptions {
       dkimOps.stream().map(dkim -> new DKIMSignOptions((JsonObject)dkim)).forEach(dkimSignOptions::add);
     }
     pipelining = config.getBoolean("pipelining", DEFAULT_ENABLE_PIPELINING);
+    multiPartOnly = config.getBoolean("multiPartOnly", DEFAULT_MULTI_PART_ONLY);
   }
 
   public MailConfig setSendBufferSize(int sendBufferSize) {
@@ -916,6 +920,29 @@ public class MailConfig extends NetClientOptions {
   }
 
   /**
+   * Should the mail message be always encoded as multipart.
+   *
+   * @return if the mail message will be encoded as multipart only.
+   */
+  public boolean isMultiPartOnly() {
+    return multiPartOnly;
+  }
+
+  /**
+   * Sets to encode multipart only or not.
+   *
+   * When sets to <code>true</code>, the mail message will be encoded as multipart even for simple mails without
+   * attachments, see https://github.com/vert-x3/vertx-mail-client/issues/161.
+   *
+   * @param multiPartOnly encoded as multipart only or not, default to <code>false</code>.
+   * @return this to be able to use the object fluently
+   */
+  public MailConfig setMultiPartOnly(boolean multiPartOnly) {
+    this.multiPartOnly = multiPartOnly;
+    return this;
+  }
+
+  /**
    * convert config object to Json representation
    *
    * @return json object of the config
@@ -966,13 +993,14 @@ public class MailConfig extends NetClientOptions {
       json.put("dkimSignOptions", array);
     }
     json.put("pipelining", pipelining);
+    json.put("multiFormatOnly", multiPartOnly);
 
     return json;
   }
 
   private List<Object> getList() {
     return Arrays.asList(hostname, port, starttls, login, username, password, authMethods, ownHostname, maxPoolSize,
-      keepAlive, allowRcptErrors, disableEsmtp, userAgent, enableDKIM, dkimSignOptions, pipelining);
+      keepAlive, allowRcptErrors, disableEsmtp, userAgent, enableDKIM, dkimSignOptions, pipelining, multiPartOnly);
   }
 
   /*

--- a/src/main/java/io/vertx/ext/mail/impl/MailClientImpl.java
+++ b/src/main/java/io/vertx/ext/mail/impl/MailClientImpl.java
@@ -148,7 +148,7 @@ public class MailClientImpl implements MailClient {
       returnResult(result, resultHandler, context);
     };
     try {
-      final MailEncoder encoder = new MailEncoder(email, hostname);
+      final MailEncoder encoder = new MailEncoder(email, hostname, config);
       final EncodedPart encodedPart = encoder.encodeMail();
       final String messageId = encoder.getMessageID();
 


### PR DESCRIPTION
Motivation:

Fixes: #161 

This PR tries to add a new option `boolean multiPartOnly` into `MailConfig` as the trigger to roll back the Vert.x 3 behavior, which always sends mails as multipart format as long as the attachments is not null(even it is empty list). It defaults to `false` which checks the content to decide if the mail format is multipart or not.

To roll back the Vert.x 3 behavior, you need to call: `mailConfig.setMultiPartOnly(true)`.

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
