### PR TITLE
Includes name of invalid email in the exception message

### DIFF
--- a/src/main/java/io/vertx/ext/mail/mailencoder/EmailAddress.java
+++ b/src/main/java/io/vertx/ext/mail/mailencoder/EmailAddress.java
@@ -55,7 +55,7 @@ public class EmailAddress {
         email = matcher.group(1);
         name = matcher.group(2);
       } else {
-        throw new IllegalArgumentException("invalid email address");
+        throw new IllegalArgumentException("invalid email address [" + fullAddress + "]");
       }
     } else if (fullAddress.contains("<")) {
       Matcher matcher = PATTERN_EMAIL_ANGLE.matcher(fullAddress);
@@ -66,7 +66,7 @@ public class EmailAddress {
         }
         email = matcher.group(2);
       } else {
-        throw new IllegalArgumentException("invalid email address");
+        throw new IllegalArgumentException("invalid email address [" + fullAddress + "]");
       }
     } else {
       email = fullAddress;
@@ -76,7 +76,7 @@ public class EmailAddress {
     // this only catches very simple errors
     // mostly to avoid protocol errors due to spaces and newlines
     if (!PATTERN_EMAIL_INVALID.matcher(email).matches()) {
-      throw new IllegalArgumentException("invalid email address");
+      throw new IllegalArgumentException("invalid email address [" + fullAddress + "]");
     }
 
   }


### PR DESCRIPTION
Motivation:

Including name of invalid email address in the exception message would likely help someone to know whats really going on.

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
