### PR TITLE
[Issue-175] Ignore the exception after quit has been sent

### DIFF
--- a/src/main/java/io/vertx/ext/mail/impl/SMTPConnection.java
+++ b/src/main/java/io/vertx/ext/mail/impl/SMTPConnection.java
@@ -117,8 +117,13 @@ class SMTPConnection {
   void handleNSException(Throwable t) {
     if (!socketClosed && !shutdown) {
       shutdown();
-      log.debug("got an exception on the netsocket", t);
-      handleError(t);
+      // some SMTP servers may not close the TCP connection gracefully
+      // https://github.com/vert-x3/vertx-mail-client/issues/175
+      if (quitSent) {
+        log.debug("got an exception on the netsocket after quit sent", t);
+      } else {
+        handleError(t);
+      }
     } else {
       log.debug("not returning follow-up exception", t);
     }


### PR DESCRIPTION
Motivation:

Fixes #175 

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines


Some SMTP servers may close the TCP connection with `[RST, ACK]` sequence right after replying the `QUIT` SMTP command, which leads to client exception with `connection reset by peer`. logging the exception in debug only.

I don't see how I can mock the TCP termination, so this PR does not have tests included.
