### PR TITLE
[Issue-172] Support enhanced status code

### DIFF
--- a/src/main/java/io/vertx/ext/mail/impl/Capabilities.java
+++ b/src/main/java/io/vertx/ext/mail/impl/Capabilities.java
@@ -57,6 +57,11 @@ class Capabilities {
   private boolean capaPipelining;
 
   /**
+   * if the server supports ENHANCEDSTATUSCODES
+   */
+  private boolean capaEnhancedStatusCodes;
+
+  /**
    * @return Set of Strings of capabilities
    */
   Set<String> getCapaAuth() {
@@ -75,6 +80,13 @@ class Capabilities {
    */
   boolean isCapaPipelining() {
     return capaPipelining;
+  }
+
+  /**
+   * @return if the server supports ENHANCEDSTATUSCODES
+   */
+  boolean isCapaEnhancedStatusCodes() {
+    return capaEnhancedStatusCodes;
   }
 
   /**
@@ -102,6 +114,9 @@ class Capabilities {
       }
       if (c.equals("PIPELINING")) {
         capaPipelining = true;
+      }
+      if (c.equals("ENHANCEDSTATUSCODES")) {
+        capaEnhancedStatusCodes = true;
       }
       if (c.startsWith("AUTH ")) {
         capaAuth = Utils.parseCapaAuth(c.substring(5));

--- a/src/main/java/io/vertx/ext/mail/impl/SMTPAuthentication.java
+++ b/src/main/java/io/vertx/ext/mail/impl/SMTPAuthentication.java
@@ -161,7 +161,7 @@ class SMTPAuthentication {
           finished();
         }
       } else {
-        onError.handle(response.toException("AUTH " + authMethod.getName() + " failed"));
+        onError.handle(response.toException("AUTH " + authMethod.getName() + " failed", connection.getCapa().isCapaEnhancedStatusCodes()));
       }
     });
   }

--- a/src/main/java/io/vertx/ext/mail/impl/SMTPConnection.java
+++ b/src/main/java/io/vertx/ext/mail/impl/SMTPConnection.java
@@ -179,6 +179,7 @@ class SMTPConnection {
       }
       sb.append("Support STARTTLS: ").append(capa.isStartTLS()).append(", Current connection TLS: ").append(this.isSsl()).append("\n");
       sb.append("Support PIPELINING: ").append(capa.isCapaPipelining()).append("\n");
+      sb.append("Support ENHANCEDSTATUSCODES: ").append(capa.isCapaEnhancedStatusCodes()).append("\n");
       log.debug(sb);
     }
   }

--- a/src/main/java/io/vertx/ext/mail/impl/SMTPReset.java
+++ b/src/main/java/io/vertx/ext/mail/impl/SMTPReset.java
@@ -41,7 +41,7 @@ class SMTPReset {
     connection.write("RSET", message -> {
       SMTPResponse response = new SMTPResponse(message);
       if (!response.isStatusOk()) {
-        handler.handle(Future.failedFuture(response.toException("reset command failed")));
+        handler.handle(Future.failedFuture(response.toException("reset command failed", connection.getCapa().isCapaEnhancedStatusCodes())));
       } else {
         handler.handle(Future.succeededFuture(connection));
       }

--- a/src/main/java/io/vertx/ext/mail/impl/SMTPResponse.java
+++ b/src/main/java/io/vertx/ext/mail/impl/SMTPResponse.java
@@ -63,10 +63,14 @@ class SMTPResponse {
   }
 
   SMTPException toException(String message) {
+    return toException(message, false);
+  }
+
+  SMTPException toException(String message, boolean supportEnhancementStatusCode) {
     if (isStatusOk()) {
       throw new IllegalStateException("Status is OK, no exceptions");
     }
-    return new SMTPException(message, replyCode, lines);
+    return new SMTPException(message, replyCode, lines, supportEnhancementStatusCode);
   }
 
 }

--- a/src/main/java/io/vertx/ext/mail/impl/SMTPSendMail.java
+++ b/src/main/java/io/vertx/ext/mail/impl/SMTPSendMail.java
@@ -140,7 +140,7 @@ class SMTPSendMail {
                 SMTPResponse response = new SMTPResponse(message);
                 if (i == 0) {
                   if (!response.isStatusOk()) {
-                    evenlopePromise.fail(response.toException("sender address not accepted"));
+                    evenlopePromise.fail(response.toException("sender address not accepted", connection.getCapa().isCapaEnhancedStatusCodes()));
                     return;
                   }
                 } else if (i < evenlopeResult.length - 1) {
@@ -148,7 +148,7 @@ class SMTPSendMail {
                     mailResult.getRecipients().add(allRecipients.get(i - 1));
                   } else {
                     if (!config.isAllowRcptErrors()) {
-                      evenlopePromise.fail(response.toException("recipient address not accepted"));
+                      evenlopePromise.fail(response.toException("recipient address not accepted", connection.getCapa().isCapaEnhancedStatusCodes()));
                       return;
                     }
                   }
@@ -161,7 +161,7 @@ class SMTPSendMail {
                       return;
                     }
                   } else {
-                    evenlopePromise.fail(response.toException("DATA command not accepted"));
+                    evenlopePromise.fail(response.toException("DATA command not accepted", connection.getCapa().isCapaEnhancedStatusCodes()));
                     return;
                   }
                 }
@@ -196,7 +196,7 @@ class SMTPSendMail {
       if (response.isStatusOk()) {
         promise.complete();
       } else {
-        promise.fail(response.toException("sender address not accepted"));
+        promise.fail(response.toException("sender address not accepted", connection.getCapa().isCapaEnhancedStatusCodes()));
       }
     });
     return promise.future();
@@ -219,7 +219,7 @@ class SMTPSendMail {
             if (config.isAllowRcptErrors()) {
               promise.complete();
             } else {
-              promise.fail(response.toException("recipient address not accepted"));
+              promise.fail(response.toException("recipient address not accepted", connection.getCapa().isCapaEnhancedStatusCodes()));
             }
           }
         } catch (Exception e) {
@@ -244,7 +244,7 @@ class SMTPSendMail {
           if (response.isStatusOk()) {
             promise.complete(true);
           } else {
-            promise.fail(response.toException("DATA command not accepted"));
+            promise.fail(response.toException("DATA command not accepted", connection.getCapa().isCapaEnhancedStatusCodes()));
           }
         });
       } else {
@@ -286,7 +286,7 @@ class SMTPSendMail {
         if (response.isStatusOk()) {
           promise.complete(mailResult);
         } else {
-          promise.fail(response.toException("sending data failed"));
+          promise.fail(response.toException("sending data failed", connection.getCapa().isCapaEnhancedStatusCodes()));
         }
       }));
     } catch (Exception e) {

--- a/src/test/java/io/vertx/ext/mail/MailEnhancedStatusCodesTest.java
+++ b/src/test/java/io/vertx/ext/mail/MailEnhancedStatusCodesTest.java
@@ -1,0 +1,256 @@
+/*
+ *  Copyright (c) 2011-2021 The original author or authors
+ *
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  and Apache License v2.0 which accompanies this distribution.
+ *
+ *       The Eclipse Public License is available at
+ *       http://www.eclipse.org/legal/epl-v10.html
+ *
+ *       The Apache License v2.0 is available at
+ *       http://www.opensource.org/licenses/apache2.0.php
+ *
+ *  You may elect to redistribute this code under either of these licenses.
+ */
+
+package io.vertx.ext.mail;
+
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Tests on enhanced status codes
+ *
+ * @author <a href="mailto:aoingl@gmail.com">Lin Gao</a>
+ */
+@RunWith(VertxUnitRunner.class)
+public class MailEnhancedStatusCodesTest extends SMTPTestDummy {
+
+  @Test
+  public void testStatusCodeOutOfBusiness(TestContext context) {
+    this.testContext = context;
+    smtpServer.setDialogue("500 example.com ESMTP. It is not the time for business, bye.");
+    MailClient mailClient = mailClientDefault();
+    mailClient.sendMail(exampleMessage()).onComplete(testContext.asyncAssertFailure(e -> {
+      Assert.assertEquals(SMTPException.class, e.getClass());
+      SMTPException se = (SMTPException)e;
+      Assert.assertTrue(se.isPermanent());
+      Assert.assertEquals(SMTPException.EnhancedStatus.OTHER_UNKNOWN, se.getEnhancedStatus());
+      Assert.assertEquals(0, se.getEnhancedStatus().getDetail());
+      mailClient.close();
+    }));
+  }
+
+  @Test
+  public void testStatusCodeHeloNotSupported(TestContext context) {
+    this.testContext = context;
+    smtpServer.setDialogue("220 example.com ESMTP. welcome",
+      "HELO",
+      "500 HELO not supported",
+      "QUIT",
+      "221 2.0.0 Bye");
+    MailConfig mailConfig = defaultConfig();
+    mailConfig.setDisableEsmtp(true);
+    MailClient mailClient = MailClient.create(vertx, mailConfig);
+    mailClient.sendMail(exampleMessage()).onComplete(testContext.asyncAssertFailure(e -> {
+      Assert.assertEquals(SMTPException.class, e.getClass());
+      SMTPException se = (SMTPException)e;
+      Assert.assertTrue(se.isPermanent());
+      Assert.assertEquals(SMTPException.EnhancedStatus.OTHER_UNKNOWN, se.getEnhancedStatus());
+      Assert.assertEquals(0, se.getEnhancedStatus().getDetail());
+      mailClient.close();
+    }));
+  }
+
+  @Test
+  public void testStatusCodeAddressFailed(TestContext context) {
+    this.testContext = context;
+    smtpServer.setDialogue("220 example.com ESMTP",
+      "EHLO",
+      "250-example.com\n" +
+        "250-ENHANCEDSTATUSCODES\n" +
+        "250 AUTH LOGIN",
+      "MAIL FROM",
+      "415 4.1.5 Destination address valid",
+      "QUIT",
+      "221 2.0.0 Bye");
+    MailConfig mailConfig = defaultConfig();
+    MailClient mailClient = MailClient.create(vertx, mailConfig);
+    mailClient.sendMail(exampleMessage()).onComplete(testContext.asyncAssertFailure(e -> {
+      Assert.assertEquals(SMTPException.class, e.getClass());
+      SMTPException se = (SMTPException)e;
+      Assert.assertTrue(se.isTransient());
+      Assert.assertEquals(SMTPException.EnhancedStatus.OTHER_ADDRESS, se.getEnhancedStatus());
+      Assert.assertEquals(5, se.getEnhancedStatus().getDetail());
+      mailClient.close();
+    }));
+  }
+
+  @Test
+  public void testStatusCodeMailboxFailed(TestContext context) {
+    this.testContext = context;
+    smtpServer.setDialogue("220 example.com ESMTP",
+      "EHLO",
+      "250-example.com\n" +
+        "250-ENHANCEDSTATUSCODES\n" +
+        "250 AUTH LOGIN",
+      "MAIL FROM",
+      "250 2.1.0 Ok",
+      "RCPT TO",
+      "425 4.2.3 Mailbox is full",
+      "QUIT",
+      "221 2.0.0 Bye");
+    MailConfig mailConfig = defaultConfig();
+    MailClient mailClient = MailClient.create(vertx, mailConfig);
+    mailClient.sendMail(exampleMessage()).onComplete(testContext.asyncAssertFailure(e -> {
+      Assert.assertEquals(SMTPException.class, e.getClass());
+      SMTPException se = (SMTPException)e;
+      Assert.assertTrue(se.isTransient());
+      Assert.assertEquals(SMTPException.EnhancedStatus.OTHER_MAILBOX, se.getEnhancedStatus());
+      Assert.assertEquals(3, se.getEnhancedStatus().getDetail());
+      mailClient.close();
+    }));
+  }
+
+  @Test
+  public void testStatusCodeMailSystemFailed(TestContext context) {
+    this.testContext = context;
+    smtpServer.setDialogue("220 example.com ESMTP",
+      "EHLO",
+      "250-example.com\n" +
+        "250-ENHANCEDSTATUSCODES\n" +
+        "250 AUTH LOGIN",
+      "MAIL FROM",
+      "250 2.1.0 Ok",
+      "RCPT TO",
+      "432 4.3.2 System not accepting network messages",
+      "QUIT",
+      "221 2.0.0 Bye");
+    MailConfig mailConfig = defaultConfig();
+    MailClient mailClient = MailClient.create(vertx, mailConfig);
+    mailClient.sendMail(exampleMessage()).onComplete(testContext.asyncAssertFailure(e -> {
+      Assert.assertEquals(SMTPException.class, e.getClass());
+      SMTPException se = (SMTPException)e;
+      Assert.assertTrue(se.isTransient());
+      Assert.assertEquals(SMTPException.EnhancedStatus.OTHER_MAIL_SYSTEM, se.getEnhancedStatus());
+      Assert.assertEquals(2, se.getEnhancedStatus().getDetail());
+      mailClient.close();
+    }));
+  }
+
+  @Test
+  public void testStatusCodeNetworkFailed(TestContext context) {
+    this.testContext = context;
+    smtpServer.setDialogue("220 example.com ESMTP",
+      "EHLO",
+      "250-example.com\n" +
+        "250-ENHANCEDSTATUSCODES\n" +
+        "250 PIPELINING",
+      "MAIL FROM",
+      "250 2.1.0 Ok",
+      "RCPT TO",
+      "250 2.1.5 Ok",
+      "DATA",
+      "550 5.4.2 Bad connection",
+      "QUIT",
+      "221 2.0.0 Bye");
+    MailConfig mailConfig = defaultConfig();
+    MailClient mailClient = MailClient.create(vertx, mailConfig);
+    mailClient.sendMail(exampleMessage()).onComplete(testContext.asyncAssertFailure(e -> {
+      Assert.assertEquals(SMTPException.class, e.getClass());
+      SMTPException se = (SMTPException)e;
+      Assert.assertTrue(se.isPermanent());
+      Assert.assertEquals(SMTPException.EnhancedStatus.OTHER_NETWORK, se.getEnhancedStatus());
+      Assert.assertEquals(2, se.getEnhancedStatus().getDetail());
+      mailClient.close();
+    }));
+  }
+
+  @Test
+  public void testStatusCodeDeliveryFailed(TestContext context) {
+    this.testContext = context;
+    smtpServer.setDialogue("220 example.com ESMTP",
+      "EHLO",
+      "250-example.com\n" +
+        "250-ENHANCEDSTATUSCODES\n" +
+        "250 PIPELINING",
+      "MAIL FROM",
+      "250 2.1.0 Ok",
+      "RCPT TO",
+      "553 5.5.3 Too many recipients",
+      "QUIT",
+      "221 2.0.0 Bye");
+    MailConfig mailConfig = defaultConfig();
+    MailClient mailClient = MailClient.create(vertx, mailConfig);
+    mailClient.sendMail(exampleMessage()).onComplete(testContext.asyncAssertFailure(e -> {
+      Assert.assertEquals(SMTPException.class, e.getClass());
+      SMTPException se = (SMTPException)e;
+      Assert.assertTrue(se.isPermanent());
+      Assert.assertEquals(SMTPException.EnhancedStatus.OTHER_MAIL_DELIVERY, se.getEnhancedStatus());
+      Assert.assertEquals(3, se.getEnhancedStatus().getDetail());
+      mailClient.close();
+    }));
+  }
+
+  @Test
+  public void testStatusCodeMessageContentFailed(TestContext context) {
+    this.testContext = context;
+    smtpServer.setDialogue("220 example.com ESMTP",
+      "EHLO",
+      "250-example.com\n" +
+        "250-ENHANCEDSTATUSCODES\n" +
+        "250 PIPELINING",
+      "MAIL FROM",
+      "250 2.1.0 Ok",
+      "RCPT TO",
+      "250 2.1.0 Ok",
+      "DATA",
+      "354 End data with <CR><LF>.<CR><LF>",
+      "561 5.6.1 Media not supported",
+      "QUIT",
+      "221 2.0.0 Bye");
+    MailConfig mailConfig = defaultConfig();
+    MailClient mailClient = MailClient.create(vertx, mailConfig);
+    mailClient.sendMail(exampleMessage()).onComplete(testContext.asyncAssertFailure(e -> {
+      Assert.assertEquals(SMTPException.class, e.getClass());
+      SMTPException se = (SMTPException)e;
+      Assert.assertTrue(se.isPermanent());
+      Assert.assertEquals(SMTPException.EnhancedStatus.OTHER_MAIL_MESSAGE, se.getEnhancedStatus());
+      Assert.assertEquals(1, se.getEnhancedStatus().getDetail());
+      mailClient.close();
+    }));
+  }
+
+  @Test
+  public void testStatusCodeAuthFailed(TestContext context) {
+    this.testContext = context;
+    smtpServer.setDialogue("220 example.com ESMTP",
+      "EHLO",
+      "250-example.com\n" +
+        "250-ENHANCEDSTATUSCODES\n" +
+        "250 AUTH LOGIN",
+      "AUTH LOGIN",
+      "334 VXNlcm5hbWU6",
+      "eHh4",
+      "334 UGFzc3dvcmQ6",
+      "eXl5",
+      "435 4.7.8 Error: authentication failed: authentication failure",
+      "QUIT",
+      "221 2.0.0 Bye");
+    MailConfig mailConfig = configLogin();
+    MailClient mailClient = MailClient.create(vertx, mailConfig);
+    mailClient.sendMail(exampleMessage()).onComplete(testContext.asyncAssertFailure(e -> {
+      Assert.assertEquals(SMTPException.class, e.getClass());
+      SMTPException se = (SMTPException)e;
+      Assert.assertTrue(se.isTransient());
+      Assert.assertEquals(SMTPException.EnhancedStatus.OTHER_SECURITY, se.getEnhancedStatus());
+      Assert.assertEquals(8, se.getEnhancedStatus().getDetail());
+      mailClient.close();
+    }));
+  }
+
+}

--- a/src/test/java/io/vertx/ext/mail/TestSmtpServer.java
+++ b/src/test/java/io/vertx/ext/mail/TestSmtpServer.java
@@ -130,8 +130,8 @@ public class TestSmtpServer {
                 }
               }
               if (!inputValid) {
-                socket.write("500 didn't expect commands (\"" + String.join(",", dialogue[currentLine]) + "\"/\"" + inputLine + "\")\r\n");
-                log.info("sending 500 didn't expect commands (\"" + String.join(",", dialogue[currentLine]) + "\"/\"" + inputLine + "\")");
+                socket.write("500 5.3.5 didn't expect commands (\"" + String.join(",", dialogue[currentLine]) + "\"/\"" + inputLine + "\")\r\n");
+                log.info("sending 500 5.3.5 didn't expect commands (\"" + String.join(",", dialogue[currentLine]) + "\"/\"" + inputLine + "\")");
                 // stop here
                 lines.set(dialogue.length);
               }


### PR DESCRIPTION
Motivation:

Fixes #172 

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines

This PR tries to add support for enhancement status code. When SMTP server support `ENHANCEDSTATUSCODES`, this client will try to parse the status code on exception, and `SMTPException.getCategory()` returns the category defined by https://datatracker.ietf.org/doc/html/rfc3463.
