### PR TITLE
[Issue-178] SMTPConnection clean up

### DIFF
--- a/src/main/java/io/vertx/ext/mail/impl/SMTPReset.java
+++ b/src/main/java/io/vertx/ext/mail/impl/SMTPReset.java
@@ -16,9 +16,8 @@
 
 package io.vertx.ext.mail.impl;
 
-import io.vertx.core.AsyncResult;
-import io.vertx.core.Handler;
 import io.vertx.core.Future;
+import io.vertx.core.Promise;
 
 /**
  * Handle the reset command, this is mostly used to check if the connection is
@@ -29,21 +28,20 @@ import io.vertx.core.Future;
 class SMTPReset {
 
   private final SMTPConnection connection;
-  private final Handler<AsyncResult<SMTPConnection>> handler;
 
-  SMTPReset(SMTPConnection connection, Handler<AsyncResult<SMTPConnection>> finishedHandler) {
+  SMTPReset(SMTPConnection connection) {
     this.connection = connection;
-    this.handler = finishedHandler;
   }
 
-  void start() {
-    connection.setErrorHandler(th -> handler.handle(Future.failedFuture(th)));
-    connection.write("RSET", message -> {
+  Future<SMTPConnection> start() {
+    Promise<String> promise = Promise.promise();
+    connection.write("RSET", promise);
+    return promise.future().flatMap(message -> {
       SMTPResponse response = new SMTPResponse(message);
       if (!response.isStatusOk()) {
-        handler.handle(Future.failedFuture(response.toException("reset command failed", connection.getCapa().isCapaEnhancedStatusCodes())));
+        return Future.failedFuture(response.toException("reset command failed", connection.getCapa().isCapaEnhancedStatusCodes()));
       } else {
-        handler.handle(Future.succeededFuture(connection));
+        return Future.succeededFuture(connection);
       }
     });
   }

--- a/src/test/java/io/vertx/ext/mail/impl/MailPipeliningTest.java
+++ b/src/test/java/io/vertx/ext/mail/impl/MailPipeliningTest.java
@@ -218,7 +218,6 @@ public class MailPipeliningTest extends SMTPTestDummy {
       {"250 2.1.0 Ok"},
       {"MAIL FROM", "RCPT TO", "RCPT TO", "DATA"},
       {"250 2.1.0 Ok", "550 5.1.1 Unknown user: userA@example.com", "550 5.1.1 Unknown user: userB@example.com", "554 no valid recipients given"},
-      {"250 2.0.0 Ok: queued as ABCD"},
       {"QUIT"},
       {"221 2.0.0 Bye"}
     };


### PR DESCRIPTION
Motivation: Fixes #178

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines


This PR tries to:
* Changed the `Handler<String> commandReplyHandler` in SMTPConnection to `Handler<AsyncResult<String>> commandReplyHandler`, errors during connection initiation and mail transaction will be handled by this handler as well. 
* Renamed the `errorHandler` to `exceptionHandler` and leave it to be used on any NetSocket exceptions only.
* Removing `closing` state, which can be checked by `closeHandler != null` instead
* `commandReplyHandler` will always be set/get in the connection's context so we don't need to care about multi-threads situations.

It does not affect how MailClient is used.