### PR TITLE
[Issue-198] Use quoted-printable encoding if content line exceeds 1000 characters

### DIFF
--- a/src/main/java/io/vertx/ext/mail/mailencoder/TextPart.java
+++ b/src/main/java/io/vertx/ext/mail/mailencoder/TextPart.java
@@ -22,12 +22,12 @@ class TextPart extends EncodedPart {
 
   public TextPart(String text, String mode) {
     if (Utils.mustEncode(text)) {
-      headers = MultiMap.caseInsensitiveMultiMap();;
+      headers = MultiMap.caseInsensitiveMultiMap();
       headers.set("Content-Type", "text/" + mode + "; charset=utf-8");
       headers.set("Content-Transfer-Encoding", "quoted-printable");
       part = Utils.encodeQP(text);
     } else {
-      headers = MultiMap.caseInsensitiveMultiMap();;
+      headers = MultiMap.caseInsensitiveMultiMap();
       headers.set("Content-Type", "text/" + mode);
       headers.set("Content-Transfer-Encoding", "7bit");
       part = text;

--- a/src/main/java/io/vertx/ext/mail/mailencoder/Utils.java
+++ b/src/main/java/io/vertx/ext/mail/mailencoder/Utils.java
@@ -81,10 +81,20 @@ public class Utils {
    * if these are there are no other chars to encode
    */
   static boolean mustEncode(String s) {
+    int lineLen = 0;
     for (int i = 0; i < s.length(); i++) {
       final char ch = s.charAt(i);
       if (ch != '=' && ch != '\t' && mustEncode(ch)) {
         return true;
+      }
+      if (ch == '\n') {
+        lineLen = 0;
+      } else {
+        // line limit is 1000 - CRLF = 998
+        // https://www.rfc-editor.org/rfc/rfc5322#section-2.1.1
+        if (++lineLen > 998) {
+          return true;
+        }
       }
     }
     return false;

--- a/src/test/java/io/vertx/ext/mail/MailLongMessageTest.java
+++ b/src/test/java/io/vertx/ext/mail/MailLongMessageTest.java
@@ -1,0 +1,59 @@
+/*
+ *  Copyright (c) 2011-2022 The original author or authors
+ *
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  and Apache License v2.0 which accompanies this distribution.
+ *
+ *       The Eclipse Public License is available at
+ *       http://www.eclipse.org/legal/epl-v10.html
+ *
+ *       The Apache License v2.0 is available at
+ *       http://www.opensource.org/licenses/apache2.0.php
+ *
+ *  You may elect to redistribute this code under either of these licenses.
+ */
+
+package io.vertx.ext.mail;
+
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.subethamail.wiser.WiserMessage;
+
+import javax.mail.internet.MimeMessage;
+
+import static org.hamcrest.core.StringContains.containsString;
+
+/**
+ * Test messages which has longer lines than 1000 characters.
+ *
+ * @author <a href="mailto: aoingl@gmail.com">Lin Gao</a>
+ */
+@RunWith(VertxUnitRunner.class)
+public class MailLongMessageTest extends SMTPTestWiser {
+
+  @Test
+  public void mailLongHtmlMessage(TestContext testContext) {
+    this.testContext=testContext;
+    // each segment length is 50
+    final String segment = "this_is_a_very_long_link_than_1000_ascii_character";
+    final StringBuilder sb = new StringBuilder("<html>\n<body>\n<a href=\"http://");
+    for (int i = 0; i < 20; i ++) {
+      sb.append(segment);
+    }
+    sb.append("\">Link</a>\n</body>\n</html>");
+    MailMessage mailMessage = new MailMessage().setFrom("from@example.com").setTo("user@example.com")
+      .setSubject("Subject").setHtml(sb.toString());
+    testSuccess(mailClientLogin(), mailMessage, () -> {
+      final WiserMessage message = wiser.getMessages().get(0);
+      testContext.assertEquals("from@example.com", message.getEnvelopeSender());
+      final MimeMessage mimeMessage = message.getMimeMessage();
+      assertThat(mimeMessage.getContentType(), containsString("text/html"));
+      testContext.assertEquals("Subject", mimeMessage.getSubject());
+      testContext.assertEquals(sb + "\n", TestUtils.conv2nl(TestUtils.inputStreamToString(mimeMessage.getInputStream())));
+    });
+  }
+
+}


### PR DESCRIPTION
Motivation: Fixes #198 

Explain here the context, and why you're making that change, what is the problem you're trying to solve.

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
