### PR TITLE
Revert "Bump log4j2.version from 2.17.1 to 2.19.0"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
   <properties>
     <stack.version>4.4.0-SNAPSHOT</stack.version>
     <jar.manifest>${project.basedir}/src/main/resources/META-INF/MANIFEST.MF</jar.manifest>
-    <log4j2.version>2.19.0</log4j2.version>
+    <log4j2.version>2.17.1</log4j2.version>
     <slf4j.version>1.7.21</slf4j.version>
   </properties>
 


### PR DESCRIPTION
Reverts vert-x3/vertx-mail-client#192

for now we consistently use 2.17.1 everywhere in vertx when needed