### PR TITLE
Replace callbacks with futures

### DIFF
--- a/src/main/java/io/vertx/ext/mail/impl/MailAttachmentImpl.java
+++ b/src/main/java/io/vertx/ext/mail/impl/MailAttachmentImpl.java
@@ -62,7 +62,6 @@ public class MailAttachmentImpl implements MailAttachment {
     this.contentType = other.contentType;
     this.disposition = other.disposition;
     this.description = other.description;
-    this.description = other.description;
     this.contentId = other.contentId;
     this.headers = other.headers == null ? null : MultiMap.caseInsensitiveMultiMap().addAll(other.headers);
     this.size = other.size;

--- a/src/main/java/io/vertx/ext/mail/impl/MailClientImpl.java
+++ b/src/main/java/io/vertx/ext/mail/impl/MailClientImpl.java
@@ -78,60 +78,76 @@ public class MailClientImpl implements MailClient {
       throw new IllegalStateException("Already closed");
     }
     closed = true;
-    return Future.future(holder::close);
+    return holder.close();
   }
 
   @Override
   public Future<MailResult> sendMail(MailMessage email) {
-    return Future.future(h -> sendMail(email, h));
-  }
-
-  private MailClient sendMail(MailMessage message, Handler<AsyncResult<MailResult>> resultHandler) {
-    ContextInternal context = (ContextInternal)vertx.getOrCreateContext();
+    ContextInternal context = (ContextInternal) vertx.getOrCreateContext();
+    Promise<MailResult> promise = context.promise();
     if (!closed) {
-      if (validateHeaders(message, resultHandler, context)) {
-        if (hostname == null) {
-          vertx.<String>executeBlocking(
-            fut -> {
-              String hname;
-              if (config.getOwnHostname() != null) {
-                hname = config.getOwnHostname();
-              } else {
-                hname = Utils.getHostname();
-              }
-              fut.complete(hname);
-            }).onComplete(
-            res -> {
-              if (res.succeeded()) {
-                hostname = res.result();
-                getConnection(message, resultHandler, context);
-              } else {
-                handleError(res.cause(), resultHandler, context);
-              }
-            });
-        } else {
-          getConnection(message, resultHandler, context);
-        }
-      }
+      validateHeaders(email, context)
+        .flatMap(ignored -> getHostname())
+        .flatMap(ignored -> getConnection(promise, context))
+        .flatMap(conn -> sendMessage(email, conn, context).compose(
+          result -> returnConnToPool(result, conn, context),
+          failure -> closeFailedConn(failure, conn, context)))
+        .onComplete(promise);
     } else {
-      handleError("mail client has been closed", resultHandler, context);
+      promise.fail("mail client has been closed");
     }
-    return this;
+    return promise.future();
   }
 
-  private void getConnection(MailMessage message, Handler<AsyncResult<MailResult>> resultHandler, ContextInternal context) {
-    connectionPool.getConnection(hostname, context, result -> {
-      if (result.succeeded()) {
-        final SMTPConnection connection = result.result();
-        connection.setErrorHandler(th -> handleError(th, resultHandler, context));
-        sendMessage(message, connection, resultHandler, context);
+  private Future<Void> validateHeaders(MailMessage email, ContextInternal context) {
+    if (email.getBounceAddress() == null && email.getFrom() == null) {
+      return context.failedFuture("sender address is not present");
+    } else if ((email.getTo() == null || email.getTo().size() == 0)
+      && (email.getCc() == null || email.getCc().size() == 0)
+      && (email.getBcc() == null || email.getBcc().size() == 0)) {
+      log.warn("no recipient addresses are present");
+      return context.failedFuture("no recipient addresses are present");
+    } else {
+      return context.succeededFuture();
+    }
+  }
+
+  private Future<String> getHostname() {
+    if (hostname != null) {
+      return Future.succeededFuture(hostname);
+    }
+
+    return vertx.executeBlocking(promise -> {
+      String hname;
+      if (config.getOwnHostname() != null) {
+        hname = config.getOwnHostname();
       } else {
-        handleError(result.cause(), resultHandler, context);
+        hname = Utils.getHostname();
       }
+      hostname = hname;
+      promise.complete(hname);
     });
   }
 
-  private Future<Void> dkimFuture(Context context, EncodedPart encodedPart) {
+  private Future<SMTPConnection> getConnection(Promise<MailResult> resultHandler, ContextInternal context) {
+    Promise<SMTPConnection> promise = context.promise();
+    connectionPool.getConnection(hostname, context).onComplete(result -> {
+      if (result.succeeded()) {
+        final SMTPConnection connection = result.result();
+        connection.setErrorHandler(resultHandler::fail);
+        promise.complete(connection);
+      } else {
+        promise.fail(result.cause());
+      }
+    });
+    return promise.future();
+  }
+
+  private Future<Void> dkimSign(ContextInternal context, EncodedPart encodedPart) {
+    if (dkimSigners.isEmpty()) {
+      return context.succeededFuture();
+    }
+
     List<Future> dkimFutures = new ArrayList<>();
     // run dkim sign, and add email header after that.
     dkimSigners.forEach(dkim -> dkimFutures.add(dkim.signEmail(context, encodedPart)));
@@ -142,81 +158,30 @@ public class MailClientImpl implements MailClient {
     });
   }
 
-  private void sendMessage(MailMessage email, SMTPConnection conn, Handler<AsyncResult<MailResult>> resultHandler,
-                           ContextInternal context) {
-    Promise<MailResult> sentResultHandler = context.promise();
-    sentResultHandler.future().onComplete(mr -> {
-      if (mr.succeeded()) {
-        conn.returnToPool().onComplete(cn -> returnResult(mr, resultHandler, context));
-      } else {
-        Promise<Void> promise = context.promise();
-        promise.future().onComplete(v -> returnResult(Future.failedFuture(mr.cause()), resultHandler, context));
-        conn.quitCloseConnection(promise);
-      }
-    });
+  private Future<MailResult> sendMessage(MailMessage email, SMTPConnection conn, ContextInternal context) {
     try {
       final MailEncoder encoder = new MailEncoder(email, hostname, config);
-      final EncodedPart encodedPart = encoder.encodeMail();
+      final EncodedPart encodedPart = encoder.encodeMail(); // may throw
       final String messageId = encoder.getMessageID();
+      final SMTPSendMail sendMail = new SMTPSendMail(context, conn, email, config, encodedPart, messageId);
 
-      final SMTPSendMail sendMail = new SMTPSendMail(conn, email, config, encodedPart, messageId);
-      if (dkimSigners.isEmpty()) {
-        sendMail.startMailTransaction(sentResultHandler);
-      } else {
-        // generate the DKIM header before start
-        dkimFuture(context, encodedPart).onComplete(dkim -> context.runOnContext(h -> {
-          if (dkim.succeeded()) {
-            sendMail.startMailTransaction(sentResultHandler);
-          } else {
-            sentResultHandler.handle(Future.failedFuture(dkim.cause()));
-          }
-        }));
-      }
+      return dkimSign(context, encodedPart)
+        .flatMap(ignored -> sendMail.startMailTransaction());
     } catch (Exception e) {
-      handleError(e, sentResultHandler, context);
+      return context.failedFuture(e);
     }
   }
 
-  // do some validation before we open the connection
-  // return true on successful validation so we can stop processing above
-  private boolean validateHeaders(MailMessage email, Handler<AsyncResult<MailResult>> resultHandler, ContextInternal context) {
-    if (email.getBounceAddress() == null && email.getFrom() == null) {
-      handleError("sender address is not present", resultHandler, context);
-      return false;
-    } else if ((email.getTo() == null || email.getTo().size() == 0)
-      && (email.getCc() == null || email.getCc().size() == 0)
-      && (email.getBcc() == null || email.getBcc().size() == 0)) {
-      log.warn("no recipient addresses are present");
-      handleError("no recipient addresses are present", resultHandler, context);
-      return false;
-    } else {
-      return true;
-    }
+  private Future<MailResult> returnConnToPool(MailResult result, SMTPConnection conn, ContextInternal context) {
+    return conn.returnToPool().transform(ignored -> context.succeededFuture(result));
   }
 
-  private void handleError(String message, Handler<AsyncResult<MailResult>> resultHandler, ContextInternal context) {
-    log.debug("handleError:" + message);
-    returnResult(Future.failedFuture(message), resultHandler, context);
-  }
-
-  private void handleError(Throwable t, Handler<AsyncResult<MailResult>> resultHandler, ContextInternal context) {
-    log.debug("handleError", t);
-    returnResult(Future.failedFuture(t), resultHandler, context);
-  }
-
-  private void returnResult(AsyncResult<MailResult> result, Handler<AsyncResult<MailResult>> resultHandler, ContextInternal context) {
-    // Note - results must always be executed on the right context, asynchronously, not directly!
-    context.emit(v -> {
-      if (resultHandler != null) {
-        resultHandler.handle(result);
-      } else {
-        if (result.succeeded()) {
-          log.debug("dropping sendMail result");
-        } else {
-          log.info("dropping sendMail failure", result.cause());
-        }
-      }
-    });
+  private Future<MailResult> closeFailedConn(Throwable failure, SMTPConnection conn, ContextInternal context) {
+    Promise<MailResult> promise = context.promise();
+    Promise<Void> promiseInternal = context.promise();
+    promiseInternal.future().onComplete(ignored -> promise.fail(failure));
+    conn.quitCloseConnection(promiseInternal);
+    return promise.future();
   }
 
   SMTPConnectionPool getConnectionPool() {
@@ -253,7 +218,7 @@ public class MailClientImpl implements MailClient {
 
     MailHolder(Vertx vertx, MailConfig config, Runnable closeRunner) {
       this.closeRunner = closeRunner;
-      this.pool= new SMTPConnectionPool(vertx, config);
+      this.pool = new SMTPConnectionPool(vertx, config);
     }
 
     SMTPConnectionPool pool() {
@@ -264,14 +229,15 @@ public class MailClientImpl implements MailClient {
       refCount++;
     }
 
-    synchronized void close(Handler<AsyncResult<Void>> closedHandler) {
+    synchronized Future<Void> close() {
       if (--refCount == 0) {
-        pool.close(closedHandler);
+        Future<Void> result = pool.doClose();
         if (closeRunner != null) {
           closeRunner.run();
         }
+        return result;
       } else {
-        closedHandler.handle(Future.succeededFuture());
+        return Future.succeededFuture();
       }
     }
   }

--- a/src/main/java/io/vertx/ext/mail/impl/SMTPAuthentication.java
+++ b/src/main/java/io/vertx/ext/mail/impl/SMTPAuthentication.java
@@ -16,8 +16,10 @@
 
 package io.vertx.ext.mail.impl;
 
+import io.vertx.core.Future;
 import io.vertx.core.Handler;
-import io.vertx.core.impl.NoStackTraceThrowable;
+import io.vertx.core.Promise;
+import io.vertx.core.impl.ContextInternal;
 import io.vertx.core.impl.logging.Logger;
 import io.vertx.core.impl.logging.LoggerFactory;
 import io.vertx.ext.mail.LoginOption;
@@ -35,25 +37,24 @@ import java.util.List;
  */
 class SMTPAuthentication {
 
-  private final SMTPConnection connection;
-  private final MailConfig config;
-  private final Handler<Void> finishedHandler;
-  private final Handler<Throwable> errorHandler;
-
   private static final Logger log = LoggerFactory.getLogger(SMTPAuthentication.class);
+
+  private final SMTPConnection connection;
+
+  private final MailConfig config;
 
   private final AuthOperationFactory authOperationFactory;
 
-  SMTPAuthentication(SMTPConnection connection, MailConfig config, AuthOperationFactory authOperationFactory, Handler<Void> finishedHandler,
-                     Handler<Throwable> errorHandler) {
+  private final Promise<Void> promise;
+
+  SMTPAuthentication(ContextInternal context, SMTPConnection connection, MailConfig config, AuthOperationFactory authOperationFactory) {
     this.connection = connection;
     this.config = config;
-    this.finishedHandler = finishedHandler;
-    this.errorHandler = errorHandler;
     this.authOperationFactory = authOperationFactory;
+    this.promise = context.promise();
   }
 
-  public void start() {
+  public Future<Void> start() {
     List<String> auths = intersectAllowedMethods();
     final boolean foundAllowedMethods = !auths.isEmpty();
     if (config.getLogin() != LoginOption.DISABLED && config.getUsername() != null && config.getPassword() != null
@@ -62,14 +63,16 @@ class SMTPAuthentication {
     } else {
       if (config.getLogin() == LoginOption.REQUIRED) {
         if (!foundAllowedMethods) {
-          handleError("login is required, but no allowed AUTH methods available. You may need to do STARTTLS");
+          promise.fail("login is required, but no allowed AUTH methods available. You may need to do STARTTLS");
         } else {
-          handleError("login is required, but no credentials supplied");
+          promise.fail("login is required, but no credentials supplied");
         }
       } else {
-        finished();
+        promise.complete();
       }
     }
+
+    return promise.future();
   }
 
   /**
@@ -105,7 +108,7 @@ class SMTPAuthentication {
       }
       authMethod(auths.get(i), error -> authChain(auths, i + 1, error));
     } else {
-      handleError(e);
+      promise.fail(e);
     }
   }
 
@@ -115,7 +118,7 @@ class SMTPAuthentication {
       authMethod = authOperationFactory.createAuth(config, auth);
     } catch (IllegalArgumentException | SecurityException ex) {
       log.warn("authentication factory threw exception", ex);
-      handleError(ex);
+      promise.fail(ex);
       return;
     }
     authCmdStep(authMethod, null, onError);
@@ -158,24 +161,12 @@ class SMTPAuthentication {
           authCmdStep(authMethod, message2, onError);
         } else {
           authOperationFactory.setAuthMethod(authMethod.getName());
-          finished();
+          promise.complete();
         }
       } else {
         onError.handle(response.toException("AUTH " + authMethod.getName() + " failed", connection.getCapa().isCapaEnhancedStatusCodes()));
       }
     });
-  }
-
-  private void finished() {
-    finishedHandler.handle(null);
-  }
-
-  private void handleError(String message) {
-    errorHandler.handle(new NoStackTraceThrowable(message));
-  }
-
-  private void handleError(Throwable th) {
-    errorHandler.handle(th);
   }
 
 }

--- a/src/main/java/io/vertx/ext/mail/impl/SMTPAuthentication.java
+++ b/src/main/java/io/vertx/ext/mail/impl/SMTPAuthentication.java
@@ -153,12 +153,11 @@ class SMTPAuthentication {
       onError.handle(e);
       return;
     }
-    connection.write(nextLine, blank, message2 -> {
-      SMTPResponse response = new SMTPResponse(message2);
+    connection.write(nextLine, blank).onSuccess(response -> {
       if (response.isStatusOk()) {
         if (response.isStatusContinue()) {
-          log.debug("Auth Continue with response: " + message2);
-          authCmdStep(authMethod, message2, onError);
+          log.debug("Auth Continue with response: " + response.getValue());
+          authCmdStep(authMethod, response.getValue(), onError);
         } else {
           authOperationFactory.setAuthMethod(authMethod.getName());
           promise.complete();

--- a/src/main/java/io/vertx/ext/mail/impl/SMTPConnection.java
+++ b/src/main/java/io/vertx/ext/mail/impl/SMTPConnection.java
@@ -23,7 +23,6 @@ import io.vertx.core.Handler;
 import io.vertx.core.Promise;
 import io.vertx.core.impl.ContextInternal;
 import io.vertx.core.impl.NoStackTraceThrowable;
-import io.vertx.core.impl.future.PromiseInternal;
 import io.vertx.core.impl.logging.Logger;
 import io.vertx.core.impl.logging.LoggerFactory;
 import io.vertx.core.net.NetSocket;
@@ -33,6 +32,7 @@ import io.vertx.ext.mail.MailConfig;
 import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.regex.Pattern;
 
 /**
  * SMTP connection to a server.
@@ -44,6 +44,7 @@ import java.util.concurrent.atomic.AtomicLong;
 class SMTPConnection {
 
   private static final Logger log = LoggerFactory.getLogger(SMTPConnection.class);
+  private static final Pattern linePattern = Pattern.compile("\r\n");
 
   private final NetSocket ns;
   private final MailConfig config;
@@ -219,30 +220,41 @@ class SMTPConnection {
     commandReplyHandler = null;
   }
 
-  void writeCommands(List<String> commands, Handler<String> resultHandler) {
+  Future<SMTPResponse[]> writeCommands(List<String> commands) {
     String cmds = String.join("\r\n", commands);
-    this.nsHandler.setExpected(commands.size());
-    this.write(cmds, r -> {
+    nsHandler.setExpected(commands.size());
+    return doWrite(cmds, -1).map(response -> {
       try {
-        resultHandler.handle(r);
+        String[] lines = linePattern.split(response);
+        SMTPResponse[] result = new SMTPResponse[lines.length];
+        for (int i = 0; i < lines.length; i++) {
+          String message = lines[i];
+          result[i] = new SMTPResponse(message);
+        }
+        return result;
       } finally {
-        this.nsHandler.setExpected(1);
+        nsHandler.setExpected(1);
       }
     });
   }
 
-  /*
-   * write command without masking anything
+  /**
+   * write command without log masking
    */
-  void write(String str, Handler<String> commandResultHandler) {
-    write(str, -1, commandResultHandler);
+  Future<SMTPResponse> write(String str) {
+    return doWrite(str, -1).map(SMTPResponse::new);
   }
 
-  /*
-   * write command masking everything after position blank
+  /**
+   * write command with log masking (everything after position {@code blank} is replaced with {@code *})
    */
-  void write(String str, int blank, Handler<String> commandResultHandler) {
-    this.commandReplyHandler = commandResultHandler;
+  Future<SMTPResponse> write(String str, int blank) {
+    return doWrite(str, blank).map(SMTPResponse::new);
+  }
+
+  private Future<String> doWrite(String str, int blank) {
+    Promise<String> promise = context.promise();
+    commandReplyHandler = promise::complete;
     checkClosed();
     context.emit(roc -> {
       if (log.isDebugEnabled()) {
@@ -265,28 +277,30 @@ class SMTPConnection {
       }
       ns.write(str + "\r\n").onFailure(this::handleNSException);
     });
+    return promise.future();
   }
 
-  // write single line not expecting a reply, using drain handler
-  void writeLineWithDrainPromise(String str, boolean mayLog, Promise<Void> promise) {
+  /**
+   * write single line not expecting a reply, using drain handler
+   */
+  Future<Void> writeLineWithDrain(String str, boolean mayLog) {
     if (checkClosed()) {
-      promise.fail("Connection was closed");
-      return;
+      return context.failedFuture("Connection was closed");
     }
     if (mayLog) {
       log.debug(str);
     }
-    context.emit(roc -> {
-      if (ns.writeQueueFull()) {
-        ns.drainHandler(v -> {
-          // avoid getting confused by being called twice
-          ns.drainHandler(null);
-          ns.write(str + "\r\n").onComplete(promise);
-        });
-      } else {
+    Promise<Void> promise = context.promise();
+    if (ns.writeQueueFull()) {
+      ns.drainHandler(v -> {
+        // avoid getting confused by being called twice
+        ns.drainHandler(null);
         ns.write(str + "\r\n").onComplete(promise);
-      }
-    });
+      });
+    } else {
+      ns.write(str + "\r\n").onComplete(promise);
+    }
+    return promise.future();
   }
 
   private void handleError(Throwable t) {
@@ -321,23 +335,21 @@ class SMTPConnection {
     return ns.isSsl();
   }
 
-  void upgradeToSsl(Handler<AsyncResult<Void>> handler) {
-    ns.upgradeToSsl().onComplete(handler);
+  Future<Void> upgradeToSsl() {
+    return ns.upgradeToSsl();
   }
 
-  Future<SMTPConnection> returnToPool() {
+  Future<Void> returnToPool() {
     log.trace("return to pool");
-    Promise<SMTPConnection> promise = context.promise();
+    Promise<Void> promise = context.promise();
     try {
       final long count = emailsSent.incrementAndGet();
       boolean exceed = config.getMaxMailsPerConnection() > 0 && count >= config.getMaxMailsPerConnection();
       if (!config.isKeepAlive() || closing || exceed) {
-        Promise<Void> p = Promise.promise();
-        p.future().onComplete(conn -> {
+        quitCloseConnection().onComplete(ignored -> {
           handleClosed();
-          promise.complete(this);
+          promise.complete();
         });
-        quitCloseConnection(p);
       } else {
         // recycle
         log.trace("recycle for next use");
@@ -345,7 +357,7 @@ class SMTPConnection {
         lease.recycle();
         inuse = false;
         expirationTimestamp = expirationTimestampOf(config);
-        promise.complete(this);
+        promise.complete();
       }
     } catch (Exception e) {
       promise.fail(e);
@@ -357,10 +369,10 @@ class SMTPConnection {
    * send QUIT and close the connection, this operation waits for the success of the quit command but will close the
    * connection on exception as well
    */
-  void quitCloseConnection(Promise<Void> promise) {
+  Future<Void> quitCloseConnection() {
     quitSent = true;
     inuse = false;
-    writeLineWithDrainPromise("QUIT", true, promise);
+    return writeLineWithDrain("QUIT", true);
   }
 
   private boolean checkClosed() {
@@ -388,7 +400,7 @@ class SMTPConnection {
     closing = true;
     if (!inuse) {
       log.trace("close by sending quit in close()");
-      quitCloseConnection(promise);
+      quitCloseConnection().onComplete(promise);
     } else {
       this.closeHandler = promise;
       if (quitSent) {

--- a/src/main/java/io/vertx/ext/mail/impl/SMTPEndPoint.java
+++ b/src/main/java/io/vertx/ext/mail/impl/SMTPEndPoint.java
@@ -15,10 +15,7 @@
  */
 package io.vertx.ext.mail.impl;
 
-import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
-import io.vertx.core.Handler;
-import io.vertx.core.Promise;
 import io.vertx.core.impl.ContextInternal;
 import io.vertx.core.impl.EventLoopContext;
 import io.vertx.core.net.NetClient;
@@ -38,6 +35,7 @@ import java.util.List;
  * @author <a href="mailto: aoingl@gmail.com">Lin Gao</a>
  */
 class SMTPEndPoint extends Endpoint<Lease<SMTPConnection>> implements PoolConnector<SMTPConnection> {
+
   private final NetClient netClient;
   private final MailConfig config;
   private final ConnectionPool<SMTPConnection> pool;
@@ -61,8 +59,8 @@ class SMTPEndPoint extends Endpoint<Lease<SMTPConnection>> implements PoolConnec
     return pool.acquire(eventLoopContext, 0);
   }
 
-  void checkExpired(Handler<AsyncResult<List<SMTPConnection>>> handler) {
-    pool.evict(conn -> !conn.isValid(), handler);
+  Future<List<SMTPConnection>> checkExpired() {
+    return pool.evict(conn -> !conn.isValid());
   }
 
   @Override
@@ -78,8 +76,8 @@ class SMTPEndPoint extends Endpoint<Lease<SMTPConnection>> implements PoolConnec
       });
   }
 
-  void close(Promise<List<Future<SMTPConnection>>> promise) {
-    pool.close(promise);
+  Future<List<Future<SMTPConnection>>> doClose() {
+    return pool.close();
   }
 
   @Override

--- a/src/main/java/io/vertx/ext/mail/impl/SMTPReset.java
+++ b/src/main/java/io/vertx/ext/mail/impl/SMTPReset.java
@@ -34,15 +34,14 @@ class SMTPReset {
     this.connection = connection;
   }
 
-  Future<SMTPConnection> start(ContextInternal contextInternal) {
-    Promise<SMTPConnection> promise = contextInternal.promise();
+  Future<Void> start(ContextInternal contextInternal) {
+    Promise<Void> promise = contextInternal.promise();
     connection.setErrorHandler(promise::fail);
-    connection.write("RSET", message -> {
-      SMTPResponse response = new SMTPResponse(message);
-      if (!response.isStatusOk()) {
-        promise.fail(response.toException("reset command failed", connection.getCapa().isCapaEnhancedStatusCodes()));
+    connection.write("RSET").onSuccess(response -> {
+      if (response.isStatusOk()) {
+        promise.complete();
       } else {
-        promise.complete(connection);
+        promise.fail(response.toException("reset command failed", connection.getCapa().isCapaEnhancedStatusCodes()));
       }
     });
     return promise.future();

--- a/src/main/java/io/vertx/ext/mail/impl/SMTPResponse.java
+++ b/src/main/java/io/vertx/ext/mail/impl/SMTPResponse.java
@@ -32,12 +32,12 @@ import java.util.Objects;
 class SMTPResponse {
 
   private final int replyCode;
-  private final List<String> lines;
+  private final String message;
 
-  SMTPResponse(String line) {
-    Objects.requireNonNull(line, "SMTP response should not be null.");
-    this.replyCode = getStatusCode(line);
-    this.lines = Arrays.asList(line.split("\n"));
+  SMTPResponse(String message) {
+    Objects.requireNonNull(message, "SMTP response should not be null.");
+    this.replyCode = getStatusCode(message);
+    this.message = message;
   }
 
   private static int getStatusCode(String message) {
@@ -52,6 +52,10 @@ class SMTPResponse {
     } catch (NumberFormatException n) {
       return 500;
     }
+  }
+
+  String getValue() {
+    return message;
   }
 
   boolean isStatusOk() {
@@ -70,7 +74,8 @@ class SMTPResponse {
     if (isStatusOk()) {
       throw new IllegalStateException("Status is OK, no exceptions");
     }
-    return new SMTPException(message, replyCode, lines, supportEnhancementStatusCode);
+    List<String> replyLines = Arrays.asList(this.message.split("\n"));
+    return new SMTPException(message, replyCode, replyLines, supportEnhancementStatusCode);
   }
 
 }

--- a/src/main/java/io/vertx/ext/mail/impl/dkim/DKIMSigner.java
+++ b/src/main/java/io/vertx/ext/mail/impl/dkim/DKIMSigner.java
@@ -19,6 +19,7 @@ package io.vertx.ext.mail.impl.dkim;
 import io.vertx.codegen.annotations.Nullable;
 import io.vertx.core.*;
 import io.vertx.core.buffer.Buffer;
+import io.vertx.core.impl.ContextInternal;
 import io.vertx.core.impl.logging.Logger;
 import io.vertx.core.impl.logging.LoggerFactory;
 import io.vertx.core.streams.Pipe;
@@ -179,7 +180,7 @@ public class DKIMSigner {
    * @return The Future with a result as the value of header: 'DKIM-Signature'
    */
   public Future<String> signEmail(Context context, EncodedPart encodedMessage) {
-    return bodyHashing(context, encodedMessage).map(bh -> {
+    return bodyHashing((ContextInternal) context, encodedMessage).map(bh -> {
       if (logger.isDebugEnabled()) {
         logger.debug("DKIM Body Hash: " + bh);
       }
@@ -340,12 +341,12 @@ public class DKIMSigner {
   }
 
   // https://tools.ietf.org/html/rfc6376#section-3.7
-  private Future<String> bodyHashing(Context context, EncodedPart encodedMessage) {
-    Promise<String> bodyHashPromise = Promise.promise();
+  private Future<String> bodyHashing(ContextInternal context, EncodedPart encodedMessage) {
+    Promise<String> bodyHashPromise = context.promise();
     try {
       final MessageDigest md = MessageDigest.getInstance(dkimSignOptions.getSignAlgo().hashAlgorithm());
       if (encodedMessage.parts() != null && encodedMessage.parts().size() > 0) {
-        Promise<Void> multiPartWalkThrough = Promise.promise();
+        Promise<Void> multiPartWalkThrough = context.promise();
         multiPartWalkThrough.future().onComplete(r -> {
           if (r.succeeded()) {
             try {

--- a/src/test/java/io/vertx/ext/mail/impl/SMTPConnectionPoolDummySMTPTest.java
+++ b/src/test/java/io/vertx/ext/mail/impl/SMTPConnectionPoolDummySMTPTest.java
@@ -61,17 +61,17 @@ public class SMTPConnectionPoolDummySMTPTest extends SMTPTestDummy {
 
     testContext.assertEquals(0, pool.connCount());
 
-    pool.getConnection(HOSTNAME, result -> {
+    pool.getConnection(HOSTNAME).onComplete(result -> {
       if (result.succeeded()) {
         log.debug("got 1st connection");
         testContext.assertEquals(1, pool.connCount());
         result.result().returnToPool().onComplete(v -> {
           testContext.assertEquals(1, pool.connCount());
-          pool.getConnection(HOSTNAME, result2 -> {
+          pool.getConnection(HOSTNAME).onComplete(result2 -> {
             if (result2.succeeded()) {
               log.debug("got 2nd connection");
               testContext.assertEquals(1, pool.connCount());
-              result2.result().returnToPool().onComplete(c -> pool.close(vv -> {
+              result2.result().returnToPool().onComplete(c -> pool.doClose().onComplete(vv -> {
                 testContext.assertEquals(0, pool.connCount());
                 async.complete();
               }));

--- a/src/test/java/io/vertx/ext/mail/impl/SMTPConnectionPoolShutdownTest.java
+++ b/src/test/java/io/vertx/ext/mail/impl/SMTPConnectionPoolShutdownTest.java
@@ -52,11 +52,11 @@ public class SMTPConnectionPoolShutdownTest extends SMTPTestWiser {
 
     testContext.assertEquals(0, pool.connCount());
 
-    pool.getConnection("hostname", result -> {
+    pool.getConnection("hostname").onComplete(result -> {
       if (result.succeeded()) {
         log.debug("got connection");
         testContext.assertEquals(1, pool.connCount());
-        pool.close(v1 -> {
+        pool.doClose().onComplete(v1 -> {
           log.debug("pool.close finished");
           closeFinished.set(true);
         });

--- a/src/test/java/io/vertx/ext/mail/impl/SMTPConnectionPoolTest.java
+++ b/src/test/java/io/vertx/ext/mail/impl/SMTPConnectionPoolTest.java
@@ -43,24 +43,24 @@ public class SMTPConnectionPoolTest extends SMTPTestWiser {
   public final void testConnectionPool(TestContext testContext) {
     Async async = testContext.async();
     SMTPConnectionPool pool = new SMTPConnectionPool(vertx, config);
-    pool.close(v -> async.complete());
+    pool.doClose().onComplete(ar -> async.complete());
   }
 
   /**
    * Test method for
-   * {@link io.vertx.ext.mail.impl.SMTPConnectionPool#getConnection(java.lang.String, io.vertx.core.Handler)} .
+   * {@link io.vertx.ext.mail.impl.SMTPConnectionPool#getConnection(java.lang.String)}.
    */
   @Test
   public final void testgetConnection(TestContext testContext) {
     SMTPConnectionPool pool = new SMTPConnectionPool(vertx, config);
     testContext.assertEquals(0, pool.connCount());
     Async async = testContext.async();
-    pool.getConnection("hostname", result -> {
+    pool.getConnection("hostname").onComplete(result -> {
       if (result.succeeded()) {
         testContext.assertEquals(1, pool.connCount());
         result.result().returnToPool();
         testContext.assertEquals(1, pool.connCount());
-        pool.close(v -> {
+        pool.doClose().onComplete(v -> {
           testContext.assertEquals(0, pool.connCount());
           async.complete();
         });
@@ -93,7 +93,7 @@ public class SMTPConnectionPoolTest extends SMTPTestWiser {
     SMTPConnectionPool pool = new SMTPConnectionPool(vertx, config);
     Async async = testContext.async();
     testContext.assertEquals(0, pool.connCount());
-    pool.getConnection("hostname", result -> {
+    pool.getConnection("hostname").onComplete(result -> {
       if (result.succeeded()) {
         log.debug("have got a connection");
         testContext.assertEquals(1, pool.connCount());
@@ -118,7 +118,7 @@ public class SMTPConnectionPoolTest extends SMTPTestWiser {
     SMTPConnectionPool pool = new SMTPConnectionPool(vertx, config);
     Async async = testContext.async();
     testContext.assertEquals(0, pool.connCount());
-    pool.close(v -> {
+    pool.doClose().onComplete(v -> {
       log.info("connection pool stopped");
       testContext.assertEquals(0, pool.connCount());
       async.complete();
@@ -133,11 +133,11 @@ public class SMTPConnectionPoolTest extends SMTPTestWiser {
     SMTPConnectionPool pool = new SMTPConnectionPool(vertx, config);
     Async async = testContext.async();
     testContext.assertEquals(0, pool.connCount());
-    pool.getConnection("hostname", result -> {
+    pool.getConnection("hostname").onComplete(result -> {
       if (result.succeeded()) {
         testContext.assertEquals(1, pool.connCount());
         result.result().returnToPool();
-        pool.close(v -> {
+        pool.doClose().onComplete(v -> {
           testContext.assertEquals(0, pool.connCount());
           log.info("connection pool stopped");
           async.complete();
@@ -153,7 +153,7 @@ public class SMTPConnectionPoolTest extends SMTPTestWiser {
     SMTPConnectionPool pool = new SMTPConnectionPool(vertx, config);
     pool.close();
     Async async = testContext.async();
-    pool.getConnection("hostname", result -> {
+    pool.getConnection("hostname").onComplete(result -> {
       if (result.succeeded()) {
         testContext.fail("getConnection() should fail");
       } else {
@@ -168,17 +168,17 @@ public class SMTPConnectionPoolTest extends SMTPTestWiser {
     SMTPConnectionPool pool = new SMTPConnectionPool(vertx, config);
     Async async = testContext.async();
     testContext.assertEquals(0, pool.connCount());
-    pool.getConnection("hostname", result -> {
+    pool.getConnection("hostname").onComplete(result -> {
       if (result.succeeded()) {
         testContext.assertEquals(1, pool.connCount());
-        pool.getConnection("hostname", result2 -> {
+        pool.getConnection("hostname").onComplete(result2 -> {
           if (result2.succeeded()) {
             testContext.assertNotEquals(result.result(), result2.result());
             testContext.assertEquals(2, pool.connCount());
             result.result().returnToPool();
             result2.result().returnToPool();
             testContext.assertEquals(2, pool.connCount());
-            pool.close(v -> {
+            pool.doClose().onComplete(v -> {
               testContext.assertEquals(0, pool.connCount());
               async.complete();
             });
@@ -199,19 +199,19 @@ public class SMTPConnectionPoolTest extends SMTPTestWiser {
     SMTPConnectionPool pool = new SMTPConnectionPool(vertx, config);
     Async async = testContext.async();
     testContext.assertEquals(0, pool.connCount());
-    pool.getConnection("hostname", result -> {
+    pool.getConnection("hostname").onComplete(result -> {
       if (result.succeeded()) {
         log.debug("got 1st connection");
         testContext.assertEquals(1, pool.connCount());
         result.result().returnToPool();
         testContext.assertEquals(1, pool.connCount());
-        pool.getConnection("hostname", result2 -> {
+        pool.getConnection("hostname").onComplete(result2 -> {
           if (result.succeeded()) {
             log.debug("got 2nd connection");
             testContext.assertEquals(result.result(), result2.result());
             testContext.assertEquals(1, pool.connCount());
             result2.result().returnToPool();
-            pool.close(v -> {
+            pool.doClose().onComplete(v -> {
               testContext.assertEquals(0, pool.connCount());
               async.complete();
             });
@@ -237,17 +237,17 @@ public class SMTPConnectionPoolTest extends SMTPTestWiser {
     SMTPConnectionPool pool = new SMTPConnectionPool(vertx, config);
     Async async = testContext.async();
     testContext.assertEquals(0, pool.connCount());
-    pool.getConnection("hostname", result -> {
+    pool.getConnection("hostname").onComplete(result -> {
       if (result.succeeded()) {
         testContext.assertEquals(1, pool.connCount());
         result.result().returnToPool();
         testContext.assertEquals(1, pool.connCount());
-        pool.getConnection("hostname", result2 -> {
+        pool.getConnection("hostname").onComplete(result2 -> {
           if (result.succeeded()) {
             testContext.assertEquals(result.result(), result2.result());
             testContext.assertEquals(1, pool.connCount());
             result2.result().returnToPool();
-            pool.close(v -> {
+            pool.doClose().onComplete(v -> {
               testContext.assertEquals(0, pool.connCount());
               async.complete();
             });
@@ -275,16 +275,16 @@ public class SMTPConnectionPoolTest extends SMTPTestWiser {
     AtomicBoolean connRecycled = new AtomicBoolean(false);
     SMTPConnectionPool pool = new SMTPConnectionPool(vertx, config);
     testContext.assertEquals(0, pool.connCount());
-    pool.getConnection("hostname", result -> {
+    pool.getConnection("hostname").onComplete(result -> {
       if (result.succeeded()) {
         log.debug("got connection 1st tme");
         testContext.assertEquals(1, pool.connCount());
-        pool.getConnection("hostname", result2 -> {
+        pool.getConnection("hostname").onComplete(result2 -> {
           if (result.succeeded()) {
             testContext.assertTrue(connRecycled.get(), "didn't get a connection on the 2nd try");
             log.debug("got connection 2nd time");
             testContext.assertEquals(1, pool.connCount());
-            result2.result().returnToPool().onComplete(v -> pool.close(vv -> {
+            result2.result().returnToPool().onComplete(v -> pool.doClose().onComplete(vv -> {
               testContext.assertEquals(0, pool.connCount());
               async.complete();
             }));
@@ -318,7 +318,7 @@ public class SMTPConnectionPoolTest extends SMTPTestWiser {
     Async async = testContext.async();
     SMTPConnectionPool pool = new SMTPConnectionPool(vertx, config);
     testContext.assertEquals(0, pool.connCount());
-    pool.getConnection("hostname", result -> {
+    pool.getConnection("hostname").onComplete(result -> {
       if (result.succeeded()) {
         log.debug("got connection");
         testContext.assertEquals(1, pool.connCount());
@@ -327,7 +327,7 @@ public class SMTPConnectionPoolTest extends SMTPTestWiser {
         stopSMTP(); // this closes our dummy server and consequently our
         // connection at the server end
         vertx.setTimer(1, v -> {
-          pool.close(v2 -> {
+          pool.doClose().onComplete(v2 -> {
             testContext.assertEquals(0, pool.connCount());
             async.complete();
           });
@@ -349,7 +349,7 @@ public class SMTPConnectionPoolTest extends SMTPTestWiser {
     Async async = testContext.async();
     SMTPConnectionPool pool = new SMTPConnectionPool(vertx, config);
     testContext.assertEquals(0, pool.connCount());
-    pool.getConnection("hostname", result -> {
+    pool.getConnection("hostname").onComplete(result -> {
       if (result.succeeded()) {
         log.debug("got connection");
         testContext.assertEquals(1, pool.connCount());
@@ -380,17 +380,17 @@ public class SMTPConnectionPoolTest extends SMTPTestWiser {
     AtomicBoolean haveGotConnection = new AtomicBoolean(false);
     SMTPConnectionPool pool = new SMTPConnectionPool(vertx, config);
     testContext.assertEquals(0, pool.connCount());
-    pool.getConnection("hostname", result -> {
+    pool.getConnection("hostname").onComplete(result -> {
       if (result.succeeded()) {
         log.debug("got connection 1st tme");
         testContext.assertEquals(1, pool.connCount());
-        pool.getConnection("hostname", result2 -> {
+        pool.getConnection("hostname").onComplete(result2 -> {
           if (result2.succeeded()) {
             haveGotConnection.set(true);
             log.debug("got connection 2nd time");
             testContext.assertEquals(1, pool.connCount());
             result2.result().returnToPool();
-            pool.close(v -> {
+            pool.doClose().onComplete(v -> {
               testContext.assertEquals(0, pool.connCount());
               async.complete();
             });
@@ -427,7 +427,7 @@ public class SMTPConnectionPoolTest extends SMTPTestWiser {
     Async async = testContext.async();
     SMTPConnectionPool pool = new SMTPConnectionPool(vertx, config);
     testContext.assertEquals(0, pool.connCount());
-    pool.getConnection("hostname", result -> {
+    pool.getConnection("hostname").onComplete(result -> {
       if (result.succeeded()) {
         log.debug("got connection");
         testContext.assertEquals(1, pool.connCount());


### PR DESCRIPTION
Motivation:

Even after the recent change (#207) to offer a future-based API, the mail client internals remained heavily callback-oriented, with some idiosyncratic quirks.

This PR changes most of the implementation to be future-based, which allows a lot of code cleanup. I wasn't aware of #194, so there's a lot of overlap. The `SMTPConnection` class still holds the 2 handlers and further refactoring would be great, I just couldn't figure it out myself. I'll see if I can find some inspiration in #194.

This PR has 2 commits (for now), the 1st mostly avoids touching `SMTPConnection` and focuses on everything around it, while the 2nd is focused on the `SMTPConnection` class. I figured this split might be helpful in reviewing (plus it reflects the order of my work), but I can squash the commits if you wish.