### PR TITLE
Replace callbacks with futures

### DIFF
--- a/src/main/java/io/vertx/ext/mail/impl/MailAttachmentImpl.java
+++ b/src/main/java/io/vertx/ext/mail/impl/MailAttachmentImpl.java
@@ -62,7 +62,6 @@ public class MailAttachmentImpl implements MailAttachment {
     this.contentType = other.contentType;
     this.disposition = other.disposition;
     this.description = other.description;
-    this.description = other.description;
     this.contentId = other.contentId;
     this.headers = other.headers == null ? null : MultiMap.caseInsensitiveMultiMap().addAll(other.headers);
     this.size = other.size;

--- a/src/main/java/io/vertx/ext/mail/impl/SMTPConnectionPool.java
+++ b/src/main/java/io/vertx/ext/mail/impl/SMTPConnectionPool.java
@@ -16,18 +16,15 @@
 
 package io.vertx.ext.mail.impl;
 
-import io.vertx.core.AsyncResult;
 import io.vertx.core.CompositeFuture;
 import io.vertx.core.Context;
 import io.vertx.core.Future;
-import io.vertx.core.Handler;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
 import io.vertx.core.impl.ContextInternal;
 import io.vertx.core.impl.logging.Logger;
 import io.vertx.core.impl.logging.LoggerFactory;
 import io.vertx.core.net.NetClient;
-import io.vertx.core.net.impl.pool.Lease;
 import io.vertx.ext.auth.PRNG;
 import io.vertx.ext.mail.MailConfig;
 import io.vertx.ext.mail.StartTLSOptions;
@@ -78,11 +75,8 @@ class SMTPConnectionPool {
   }
 
   private void checkExpired(long timer) {
-    getSMTPEndPoint().checkExpired(ar -> {
-      if (ar.succeeded()) {
-        ar.result().forEach(c -> c.quitCloseConnection(Promise.promise()));
-      }
-    });
+    getSMTPEndPoint().checkExpired()
+      .onSuccess(conns -> conns.forEach(SMTPConnection::quitCloseConnection));
     synchronized (this) {
       if (!closed) {
         timerID = vertx.setTimer(poolCleanTimeout(config), this::checkExpired);
@@ -94,72 +88,57 @@ class SMTPConnectionPool {
     return authOperationFactory;
   }
 
-  void getConnection(String hostname, Handler<AsyncResult<SMTPConnection>> resultHandler) {
-    getConnection(hostname, vertx.getOrCreateContext(), resultHandler);
+  Future<SMTPConnection> getConnection(String hostname) {
+    return getConnection(hostname, vertx.getOrCreateContext());
   }
 
-  void getConnection(String hostname, Context ctx, Handler<AsyncResult<SMTPConnection>> resultHandler) {
-    getConnection0(hostname, ctx, resultHandler, 0);
+  Future<SMTPConnection> getConnection(String hostname, Context ctx) {
+    return getConnection0(hostname, ctx, 0);
   }
 
-  private void getConnection0(String hostname, Context ctx, Handler<AsyncResult<SMTPConnection>> resultHandler, final int i) {
+  private Future<SMTPConnection> getConnection0(String hostname, Context ctx, final int retryAttempt) {
+    ContextInternal contextInternal = (ContextInternal) ctx;
     synchronized (this) {
       if (closed) {
-        resultHandler.handle(Future.failedFuture("connection pool is closed"));
-        return;
+        return contextInternal.failedFuture("connection pool is closed");
       }
     }
-    ContextInternal contextInternal = (ContextInternal)ctx;
-    Promise<Lease<SMTPConnection>> promise = contextInternal.promise();
-    promise.future()
-      .map(l -> l.get().setLease(l)).flatMap(conn -> {
-      final Future<SMTPConnection> future;
-      final boolean reset;
-      conn.setInUse();
-      if (conn.isInitialized()) {
-        reset = true;
-        Promise<SMTPConnection> connReset = contextInternal.promise();
-        new SMTPReset(conn, connReset).start();
-        future = connReset.future();
-      } else {
-        reset = false;
-        Promise<SMTPConnection> connInitial = contextInternal.promise();
-        SMTPStarter starter = new SMTPStarter(conn, this.config, hostname, authOperationFactory, connInitial);
-        try {
-          conn.init(ar -> {
-            if (ar.failed()) {
-              connInitial.fail(ar.cause());
-              return;
-            }
-            starter.serverGreeting(ar.result());
-          });
-        } catch (Exception e) {
-          connInitial.handle(Future.failedFuture(e));
-        }
-        future = connInitial.future();
-      }
-      return future.recover(t -> {
-        // close the connection as it failed either in rset or handshake
-        Promise<Void> quitPromise = contextInternal.promise();
-        if (t instanceof IOException) {
-          conn.shutdown();
-          quitPromise.fail(t);
+
+    return getSMTPEndPoint().getConnection(contextInternal, config.getConnectTimeout())
+      .map(l -> l.get().setLease(l))
+      .flatMap(conn -> {
+        final Future<SMTPConnection> future;
+        final boolean reset;
+        conn.setInUse();
+        if (conn.isInitialized()) {
+          reset = true;
+          future = new SMTPReset(conn).start(contextInternal)
+            .map(ignored -> conn);
         } else {
-          conn.quitCloseConnection(quitPromise);
+          reset = false;
+          future = conn.init()
+            .flatMap(new SMTPStarter(contextInternal, conn, config, hostname, authOperationFactory)::serverGreeting)
+            .map(ignored -> conn);
         }
-        return quitPromise.future().transform(v -> {
-          if (reset && i < RSET_MAX_RETRY) {
-            Promise<SMTPConnection> getConnAgain = contextInternal.promise();
-            log.debug("Failed on RSET, try " + (i + 1) + " time");
-            getConnection0(hostname, ctx, getConnAgain, i + 1);
-            return getConnAgain.future();
+        return future.recover(t -> {
+          // close the connection as it failed either in rset or handshake
+          Promise<Void> quitPromise = contextInternal.promise();
+          if (t instanceof IOException) {
+            conn.shutdown();
+            quitPromise.fail(t);
+          } else {
+            conn.quitCloseConnection().onComplete(quitPromise);
           }
-          conn.shutdown();
-          return Future.failedFuture(t);
+          return quitPromise.future().transform(v -> {
+            if (reset && retryAttempt < RSET_MAX_RETRY) {
+              log.debug("Failed on RSET, try " + (retryAttempt + 1) + " time");
+              return getConnection0(hostname, ctx, retryAttempt + 1);
+            }
+            conn.shutdown();
+            return contextInternal.failedFuture(t);
+          });
         });
       });
-    }).onComplete(resultHandler);
-    getSMTPEndPoint().getConnection(contextInternal, config.getConnectTimeout()).onComplete(promise);
   }
 
   private SMTPEndPoint getSMTPEndPoint() {
@@ -167,7 +146,7 @@ class SMTPConnectionPool {
   }
 
   public void close() {
-    close(h -> {
+    doClose().onComplete(h -> {
       if (h.failed()) {
         log.warn("Failed to close the pool", h.cause());
       }
@@ -175,7 +154,7 @@ class SMTPConnectionPool {
     });
   }
 
-  void close(Handler<AsyncResult<Void>> finishedHandler) {
+  Future<Void> doClose() {
     log.debug("trying to close the connection pool");
     synchronized (this) {
       if (closed) {
@@ -188,32 +167,18 @@ class SMTPConnectionPool {
       }
     }
     this.prng.close();
-    Promise<List<Future<SMTPConnection>>> closePromise = Promise.promise();
-    closePromise.future()
+    return getSMTPEndPoint().doClose()
       .flatMap(list -> {
         List<Future<Void>> futures = list.stream()
-          .map(connFuture -> {
-            Promise<Void> promise = Promise.promise();
-            connFuture.result().close(promise);
-            return promise.future();
-          })
+          .map(connFuture -> connFuture.result().close())
           .collect(Collectors.toList());
         return CompositeFuture.all(futures);
       })
       .flatMap(f -> this.netClient.close())
-      .onComplete(r -> {
+      .eventually(ignored -> {
         log.debug("Close net client");
-        if (r.succeeded()) {
-          if (finishedHandler != null) {
-            finishedHandler.handle(Future.succeededFuture());
-          }
-        } else {
-          if (finishedHandler != null) {
-            finishedHandler.handle(Future.failedFuture(r.cause()));
-          }
-        }
+        return Future.succeededFuture();
       });
-    getSMTPEndPoint().close(closePromise);
   }
 
   int connCount() {

--- a/src/main/java/io/vertx/ext/mail/impl/SMTPEndPoint.java
+++ b/src/main/java/io/vertx/ext/mail/impl/SMTPEndPoint.java
@@ -15,10 +15,7 @@
  */
 package io.vertx.ext.mail.impl;
 
-import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
-import io.vertx.core.Handler;
-import io.vertx.core.Promise;
 import io.vertx.core.impl.ContextInternal;
 import io.vertx.core.impl.EventLoopContext;
 import io.vertx.core.net.NetClient;
@@ -38,6 +35,7 @@ import java.util.List;
  * @author <a href="mailto: aoingl@gmail.com">Lin Gao</a>
  */
 class SMTPEndPoint extends Endpoint<Lease<SMTPConnection>> implements PoolConnector<SMTPConnection> {
+
   private final NetClient netClient;
   private final MailConfig config;
   private final ConnectionPool<SMTPConnection> pool;
@@ -61,8 +59,8 @@ class SMTPEndPoint extends Endpoint<Lease<SMTPConnection>> implements PoolConnec
     return pool.acquire(eventLoopContext, 0);
   }
 
-  void checkExpired(Handler<AsyncResult<List<SMTPConnection>>> handler) {
-    pool.evict(conn -> !conn.isValid(), handler);
+  Future<List<SMTPConnection>> checkExpired() {
+    return pool.evict(conn -> !conn.isValid());
   }
 
   @Override
@@ -78,8 +76,8 @@ class SMTPEndPoint extends Endpoint<Lease<SMTPConnection>> implements PoolConnec
       });
   }
 
-  void close(Promise<List<Future<SMTPConnection>>> promise) {
-    pool.close(promise);
+  Future<List<Future<SMTPConnection>>> doClose() {
+    return pool.close();
   }
 
   @Override

--- a/src/main/java/io/vertx/ext/mail/impl/SMTPReset.java
+++ b/src/main/java/io/vertx/ext/mail/impl/SMTPReset.java
@@ -16,9 +16,9 @@
 
 package io.vertx.ext.mail.impl;
 
-import io.vertx.core.AsyncResult;
-import io.vertx.core.Handler;
 import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.impl.ContextInternal;
 
 /**
  * Handle the reset command, this is mostly used to check if the connection is
@@ -29,28 +29,27 @@ import io.vertx.core.Future;
 class SMTPReset {
 
   private final SMTPConnection connection;
-  private final Handler<AsyncResult<SMTPConnection>> handler;
 
-  SMTPReset(SMTPConnection connection, Handler<AsyncResult<SMTPConnection>> finishedHandler) {
+  SMTPReset(SMTPConnection connection) {
     this.connection = connection;
-    this.handler = finishedHandler;
   }
 
-  void start() {
-    connection.setExceptionHandler(th -> handler.handle(Future.failedFuture(th)));
-    connection.write("RSET", ar -> {
+  Future<Void> start(ContextInternal contextInternal) {
+    Promise<Void> promise = contextInternal.promise();
+    connection.setExceptionHandler(promise::fail);
+    connection.write("RSET").onComplete(ar -> {
       if (ar.failed()) {
-        handler.handle(Future.failedFuture(ar.cause()));
+        promise.fail(ar.cause());
         return;
       }
-      String message = ar.result();
-      SMTPResponse response = new SMTPResponse(message);
-      if (!response.isStatusOk()) {
-        handler.handle(Future.failedFuture(response.toException("reset command failed", connection.getCapa().isCapaEnhancedStatusCodes())));
+      SMTPResponse response = ar.result();
+      if (response.isStatusOk()) {
+        promise.complete();
       } else {
-        handler.handle(Future.succeededFuture(connection));
+        promise.fail(response.toException("reset command failed", connection.getCapa().isCapaEnhancedStatusCodes()));
       }
     });
+    return promise.future();
   }
 
 }

--- a/src/main/java/io/vertx/ext/mail/impl/SMTPResponse.java
+++ b/src/main/java/io/vertx/ext/mail/impl/SMTPResponse.java
@@ -32,12 +32,12 @@ import java.util.Objects;
 class SMTPResponse {
 
   private final int replyCode;
-  private final List<String> lines;
+  private final String message;
 
-  SMTPResponse(String line) {
-    Objects.requireNonNull(line, "SMTP response should not be null.");
-    this.replyCode = getStatusCode(line);
-    this.lines = Arrays.asList(line.split("\n"));
+  SMTPResponse(String message) {
+    Objects.requireNonNull(message, "SMTP response should not be null.");
+    this.replyCode = getStatusCode(message);
+    this.message = message;
   }
 
   private static int getStatusCode(String message) {
@@ -52,6 +52,10 @@ class SMTPResponse {
     } catch (NumberFormatException n) {
       return 500;
     }
+  }
+
+  String getValue() {
+    return message;
   }
 
   boolean isStatusOk() {
@@ -70,7 +74,8 @@ class SMTPResponse {
     if (isStatusOk()) {
       throw new IllegalStateException("Status is OK, no exceptions");
     }
-    return new SMTPException(message, replyCode, lines, supportEnhancementStatusCode);
+    List<String> replyLines = Arrays.asList(this.message.split("\n"));
+    return new SMTPException(message, replyCode, replyLines, supportEnhancementStatusCode);
   }
 
 }

--- a/src/main/java/io/vertx/ext/mail/impl/dkim/DKIMSigner.java
+++ b/src/main/java/io/vertx/ext/mail/impl/dkim/DKIMSigner.java
@@ -19,6 +19,7 @@ package io.vertx.ext.mail.impl.dkim;
 import io.vertx.codegen.annotations.Nullable;
 import io.vertx.core.*;
 import io.vertx.core.buffer.Buffer;
+import io.vertx.core.impl.ContextInternal;
 import io.vertx.core.impl.logging.Logger;
 import io.vertx.core.impl.logging.LoggerFactory;
 import io.vertx.core.streams.Pipe;
@@ -179,7 +180,7 @@ public class DKIMSigner {
    * @return The Future with a result as the value of header: 'DKIM-Signature'
    */
   public Future<String> signEmail(Context context, EncodedPart encodedMessage) {
-    return bodyHashing(context, encodedMessage).map(bh -> {
+    return bodyHashing((ContextInternal) context, encodedMessage).map(bh -> {
       if (logger.isDebugEnabled()) {
         logger.debug("DKIM Body Hash: " + bh);
       }
@@ -340,12 +341,12 @@ public class DKIMSigner {
   }
 
   // https://tools.ietf.org/html/rfc6376#section-3.7
-  private Future<String> bodyHashing(Context context, EncodedPart encodedMessage) {
-    Promise<String> bodyHashPromise = Promise.promise();
+  private Future<String> bodyHashing(ContextInternal context, EncodedPart encodedMessage) {
+    Promise<String> bodyHashPromise = context.promise();
     try {
       final MessageDigest md = MessageDigest.getInstance(dkimSignOptions.getSignAlgo().hashAlgorithm());
       if (encodedMessage.parts() != null && encodedMessage.parts().size() > 0) {
-        Promise<Void> multiPartWalkThrough = Promise.promise();
+        Promise<Void> multiPartWalkThrough = context.promise();
         multiPartWalkThrough.future().onComplete(r -> {
           if (r.succeeded()) {
             try {

--- a/src/test/java/io/vertx/ext/mail/impl/SMTPConnectionPoolDummySMTPTest.java
+++ b/src/test/java/io/vertx/ext/mail/impl/SMTPConnectionPoolDummySMTPTest.java
@@ -61,17 +61,17 @@ public class SMTPConnectionPoolDummySMTPTest extends SMTPTestDummy {
 
     testContext.assertEquals(0, pool.connCount());
 
-    pool.getConnection(HOSTNAME, result -> {
+    pool.getConnection(HOSTNAME).onComplete(result -> {
       if (result.succeeded()) {
         log.debug("got 1st connection");
         testContext.assertEquals(1, pool.connCount());
         result.result().returnToPool().onComplete(v -> {
           testContext.assertEquals(1, pool.connCount());
-          pool.getConnection(HOSTNAME, result2 -> {
+          pool.getConnection(HOSTNAME).onComplete(result2 -> {
             if (result2.succeeded()) {
               log.debug("got 2nd connection");
               testContext.assertEquals(1, pool.connCount());
-              result2.result().returnToPool().onComplete(c -> pool.close(vv -> {
+              result2.result().returnToPool().onComplete(c -> pool.doClose().onComplete(vv -> {
                 testContext.assertEquals(0, pool.connCount());
                 async.complete();
               }));

--- a/src/test/java/io/vertx/ext/mail/impl/SMTPConnectionPoolShutdownTest.java
+++ b/src/test/java/io/vertx/ext/mail/impl/SMTPConnectionPoolShutdownTest.java
@@ -52,11 +52,11 @@ public class SMTPConnectionPoolShutdownTest extends SMTPTestWiser {
 
     testContext.assertEquals(0, pool.connCount());
 
-    pool.getConnection("hostname", result -> {
+    pool.getConnection("hostname").onComplete(result -> {
       if (result.succeeded()) {
         log.debug("got connection");
         testContext.assertEquals(1, pool.connCount());
-        pool.close(v1 -> {
+        pool.doClose().onComplete(v1 -> {
           log.debug("pool.close finished");
           closeFinished.set(true);
         });

--- a/src/test/java/io/vertx/ext/mail/impl/SMTPConnectionPoolTest.java
+++ b/src/test/java/io/vertx/ext/mail/impl/SMTPConnectionPoolTest.java
@@ -43,24 +43,24 @@ public class SMTPConnectionPoolTest extends SMTPTestWiser {
   public final void testConnectionPool(TestContext testContext) {
     Async async = testContext.async();
     SMTPConnectionPool pool = new SMTPConnectionPool(vertx, config);
-    pool.close(v -> async.complete());
+    pool.doClose().onComplete(ar -> async.complete());
   }
 
   /**
    * Test method for
-   * {@link io.vertx.ext.mail.impl.SMTPConnectionPool#getConnection(java.lang.String, io.vertx.core.Handler)} .
+   * {@link io.vertx.ext.mail.impl.SMTPConnectionPool#getConnection(java.lang.String)}.
    */
   @Test
   public final void testgetConnection(TestContext testContext) {
     SMTPConnectionPool pool = new SMTPConnectionPool(vertx, config);
     testContext.assertEquals(0, pool.connCount());
     Async async = testContext.async();
-    pool.getConnection("hostname", result -> {
+    pool.getConnection("hostname").onComplete(result -> {
       if (result.succeeded()) {
         testContext.assertEquals(1, pool.connCount());
         result.result().returnToPool();
         testContext.assertEquals(1, pool.connCount());
-        pool.close(v -> {
+        pool.doClose().onComplete(v -> {
           testContext.assertEquals(0, pool.connCount());
           async.complete();
         });
@@ -93,7 +93,7 @@ public class SMTPConnectionPoolTest extends SMTPTestWiser {
     SMTPConnectionPool pool = new SMTPConnectionPool(vertx, config);
     Async async = testContext.async();
     testContext.assertEquals(0, pool.connCount());
-    pool.getConnection("hostname", result -> {
+    pool.getConnection("hostname").onComplete(result -> {
       if (result.succeeded()) {
         log.debug("have got a connection");
         testContext.assertEquals(1, pool.connCount());
@@ -118,7 +118,7 @@ public class SMTPConnectionPoolTest extends SMTPTestWiser {
     SMTPConnectionPool pool = new SMTPConnectionPool(vertx, config);
     Async async = testContext.async();
     testContext.assertEquals(0, pool.connCount());
-    pool.close(v -> {
+    pool.doClose().onComplete(v -> {
       log.info("connection pool stopped");
       testContext.assertEquals(0, pool.connCount());
       async.complete();
@@ -133,11 +133,11 @@ public class SMTPConnectionPoolTest extends SMTPTestWiser {
     SMTPConnectionPool pool = new SMTPConnectionPool(vertx, config);
     Async async = testContext.async();
     testContext.assertEquals(0, pool.connCount());
-    pool.getConnection("hostname", result -> {
+    pool.getConnection("hostname").onComplete(result -> {
       if (result.succeeded()) {
         testContext.assertEquals(1, pool.connCount());
         result.result().returnToPool();
-        pool.close(v -> {
+        pool.doClose().onComplete(v -> {
           testContext.assertEquals(0, pool.connCount());
           log.info("connection pool stopped");
           async.complete();
@@ -153,7 +153,7 @@ public class SMTPConnectionPoolTest extends SMTPTestWiser {
     SMTPConnectionPool pool = new SMTPConnectionPool(vertx, config);
     pool.close();
     Async async = testContext.async();
-    pool.getConnection("hostname", result -> {
+    pool.getConnection("hostname").onComplete(result -> {
       if (result.succeeded()) {
         testContext.fail("getConnection() should fail");
       } else {
@@ -168,17 +168,17 @@ public class SMTPConnectionPoolTest extends SMTPTestWiser {
     SMTPConnectionPool pool = new SMTPConnectionPool(vertx, config);
     Async async = testContext.async();
     testContext.assertEquals(0, pool.connCount());
-    pool.getConnection("hostname", result -> {
+    pool.getConnection("hostname").onComplete(result -> {
       if (result.succeeded()) {
         testContext.assertEquals(1, pool.connCount());
-        pool.getConnection("hostname", result2 -> {
+        pool.getConnection("hostname").onComplete(result2 -> {
           if (result2.succeeded()) {
             testContext.assertNotEquals(result.result(), result2.result());
             testContext.assertEquals(2, pool.connCount());
             result.result().returnToPool();
             result2.result().returnToPool();
             testContext.assertEquals(2, pool.connCount());
-            pool.close(v -> {
+            pool.doClose().onComplete(v -> {
               testContext.assertEquals(0, pool.connCount());
               async.complete();
             });
@@ -199,19 +199,19 @@ public class SMTPConnectionPoolTest extends SMTPTestWiser {
     SMTPConnectionPool pool = new SMTPConnectionPool(vertx, config);
     Async async = testContext.async();
     testContext.assertEquals(0, pool.connCount());
-    pool.getConnection("hostname", result -> {
+    pool.getConnection("hostname").onComplete(result -> {
       if (result.succeeded()) {
         log.debug("got 1st connection");
         testContext.assertEquals(1, pool.connCount());
         result.result().returnToPool();
         testContext.assertEquals(1, pool.connCount());
-        pool.getConnection("hostname", result2 -> {
+        pool.getConnection("hostname").onComplete(result2 -> {
           if (result.succeeded()) {
             log.debug("got 2nd connection");
             testContext.assertEquals(result.result(), result2.result());
             testContext.assertEquals(1, pool.connCount());
             result2.result().returnToPool();
-            pool.close(v -> {
+            pool.doClose().onComplete(v -> {
               testContext.assertEquals(0, pool.connCount());
               async.complete();
             });
@@ -237,17 +237,17 @@ public class SMTPConnectionPoolTest extends SMTPTestWiser {
     SMTPConnectionPool pool = new SMTPConnectionPool(vertx, config);
     Async async = testContext.async();
     testContext.assertEquals(0, pool.connCount());
-    pool.getConnection("hostname", result -> {
+    pool.getConnection("hostname").onComplete(result -> {
       if (result.succeeded()) {
         testContext.assertEquals(1, pool.connCount());
         result.result().returnToPool();
         testContext.assertEquals(1, pool.connCount());
-        pool.getConnection("hostname", result2 -> {
+        pool.getConnection("hostname").onComplete(result2 -> {
           if (result.succeeded()) {
             testContext.assertEquals(result.result(), result2.result());
             testContext.assertEquals(1, pool.connCount());
             result2.result().returnToPool();
-            pool.close(v -> {
+            pool.doClose().onComplete(v -> {
               testContext.assertEquals(0, pool.connCount());
               async.complete();
             });
@@ -275,16 +275,16 @@ public class SMTPConnectionPoolTest extends SMTPTestWiser {
     AtomicBoolean connRecycled = new AtomicBoolean(false);
     SMTPConnectionPool pool = new SMTPConnectionPool(vertx, config);
     testContext.assertEquals(0, pool.connCount());
-    pool.getConnection("hostname", result -> {
+    pool.getConnection("hostname").onComplete(result -> {
       if (result.succeeded()) {
         log.debug("got connection 1st tme");
         testContext.assertEquals(1, pool.connCount());
-        pool.getConnection("hostname", result2 -> {
+        pool.getConnection("hostname").onComplete(result2 -> {
           if (result.succeeded()) {
             testContext.assertTrue(connRecycled.get(), "didn't get a connection on the 2nd try");
             log.debug("got connection 2nd time");
             testContext.assertEquals(1, pool.connCount());
-            result2.result().returnToPool().onComplete(v -> pool.close(vv -> {
+            result2.result().returnToPool().onComplete(v -> pool.doClose().onComplete(vv -> {
               testContext.assertEquals(0, pool.connCount());
               async.complete();
             }));
@@ -318,7 +318,7 @@ public class SMTPConnectionPoolTest extends SMTPTestWiser {
     Async async = testContext.async();
     SMTPConnectionPool pool = new SMTPConnectionPool(vertx, config);
     testContext.assertEquals(0, pool.connCount());
-    pool.getConnection("hostname", result -> {
+    pool.getConnection("hostname").onComplete(result -> {
       if (result.succeeded()) {
         log.debug("got connection");
         testContext.assertEquals(1, pool.connCount());
@@ -327,7 +327,7 @@ public class SMTPConnectionPoolTest extends SMTPTestWiser {
         stopSMTP(); // this closes our dummy server and consequently our
         // connection at the server end
         vertx.setTimer(1, v -> {
-          pool.close(v2 -> {
+          pool.doClose().onComplete(v2 -> {
             testContext.assertEquals(0, pool.connCount());
             async.complete();
           });
@@ -349,7 +349,7 @@ public class SMTPConnectionPoolTest extends SMTPTestWiser {
     Async async = testContext.async();
     SMTPConnectionPool pool = new SMTPConnectionPool(vertx, config);
     testContext.assertEquals(0, pool.connCount());
-    pool.getConnection("hostname", result -> {
+    pool.getConnection("hostname").onComplete(result -> {
       if (result.succeeded()) {
         log.debug("got connection");
         testContext.assertEquals(1, pool.connCount());
@@ -380,17 +380,17 @@ public class SMTPConnectionPoolTest extends SMTPTestWiser {
     AtomicBoolean haveGotConnection = new AtomicBoolean(false);
     SMTPConnectionPool pool = new SMTPConnectionPool(vertx, config);
     testContext.assertEquals(0, pool.connCount());
-    pool.getConnection("hostname", result -> {
+    pool.getConnection("hostname").onComplete(result -> {
       if (result.succeeded()) {
         log.debug("got connection 1st tme");
         testContext.assertEquals(1, pool.connCount());
-        pool.getConnection("hostname", result2 -> {
+        pool.getConnection("hostname").onComplete(result2 -> {
           if (result2.succeeded()) {
             haveGotConnection.set(true);
             log.debug("got connection 2nd time");
             testContext.assertEquals(1, pool.connCount());
             result2.result().returnToPool();
-            pool.close(v -> {
+            pool.doClose().onComplete(v -> {
               testContext.assertEquals(0, pool.connCount());
               async.complete();
             });
@@ -427,7 +427,7 @@ public class SMTPConnectionPoolTest extends SMTPTestWiser {
     Async async = testContext.async();
     SMTPConnectionPool pool = new SMTPConnectionPool(vertx, config);
     testContext.assertEquals(0, pool.connCount());
-    pool.getConnection("hostname", result -> {
+    pool.getConnection("hostname").onComplete(result -> {
       if (result.succeeded()) {
         log.debug("got connection");
         testContext.assertEquals(1, pool.connCount());


### PR DESCRIPTION
Motivation:

Even after the recent change (#207) to offer a future-based API, the mail client internals remained heavily callback-oriented, with some idiosyncratic quirks. This PR changes most of the implementation to be future-based, which allows a lot of code cleanup.