### PR TITLE
FIX#219: bare <LF> received after DATA

### DIFF
--- a/src/main/java/io/vertx/ext/mail/impl/SMTPSendMail.java
+++ b/src/main/java/io/vertx/ext/mail/impl/SMTPSendMail.java
@@ -287,7 +287,12 @@ class SMTPSendMail {
 
   private Future<Void> sendMailHeaders(MultiMap headers) {
     StringBuilder sb = new StringBuilder();
-    headers.forEach(header -> sb.append(header.getKey()).append(": ").append(header.getValue()).append("\r\n"));
+    headers.forEach(header -> {
+      String rawValue = header.getValue();
+      assert !rawValue.contains("\r\n");
+      String crlfValue = rawValue.replaceAll("\n", "\r\n");
+      sb.append(header.getKey()).append(": ").append(crlfValue).append("\r\n");
+    });
     final String headerLines = sb.toString();
     return connection.writeLineWithDrain(headerLines, written.getAndAdd(headerLines.length()) < 1000);
   }

--- a/src/main/java/io/vertx/ext/mail/impl/SMTPSendMail.java
+++ b/src/main/java/io/vertx/ext/mail/impl/SMTPSendMail.java
@@ -288,10 +288,10 @@ class SMTPSendMail {
   private Future<Void> sendMailHeaders(MultiMap headers) {
     StringBuilder sb = new StringBuilder();
     headers.forEach(header -> {
-      String rawValue = header.getValue();
-      assert !rawValue.contains("\r\n");
-      String crlfValue = rawValue.replaceAll("\n", "\r\n");
-      sb.append(header.getKey()).append(": ").append(crlfValue).append("\r\n");
+      sb.append(header.getKey()).append(": ");
+      for (String valueLine : header.getValue().split("\n")){
+        sb.append(valueLine).append("\r\n");
+      }
     });
     final String headerLines = sb.toString();
     return connection.writeLineWithDrain(headerLines, written.getAndAdd(headerLines.length()) < 1000);

--- a/src/test/java/io/vertx/ext/mail/AdditionalAsserts.java
+++ b/src/test/java/io/vertx/ext/mail/AdditionalAsserts.java
@@ -23,6 +23,6 @@ package io.vertx.ext.mail;
  * @author <a href="http://oss.lehmann.cx/">Alexander Lehmann</a>
  */
 @FunctionalInterface
-interface AdditionalAsserts {
+public interface AdditionalAsserts {
   void doAsserts() throws Exception;
 }

--- a/src/test/java/io/vertx/ext/mail/SMTPTestWiser.java
+++ b/src/test/java/io/vertx/ext/mail/SMTPTestWiser.java
@@ -47,7 +47,11 @@ public class SMTPTestWiser extends SMTPTestBase {
 
   protected Wiser wiser;
 
+
   protected void startSMTP(String factory) {
+    startSMTP(factory, false);
+  }
+  protected void startSMTP(String factory, boolean bareLf) {
     wiser = new Wiser();
 
     wiser.setPort(1587);
@@ -80,47 +84,49 @@ public class SMTPTestWiser extends SMTPTestBase {
 
     Security.setProperty("ssl.SocketFactory.provider", factory);
 
-    MessageHandlerFactory originalFactory = wiser.getServer().getMessageHandlerFactory();
-    wiser.getServer().setMessageHandlerFactory(ctx -> {
-      final MessageHandler originalHandler = originalFactory.create(ctx);
-      return new MessageHandler() {
-        @Override
-        public void from(String from) throws RejectException {
-          originalHandler.from(from);
-        }
+    if(bareLf) {
+      MessageHandlerFactory originalFactory = wiser.getServer().getMessageHandlerFactory();
+      wiser.getServer().setMessageHandlerFactory(ctx -> {
+        final MessageHandler originalHandler = originalFactory.create(ctx);
+        return new MessageHandler() {
+          @Override
+          public void from(String from) throws RejectException {
+            originalHandler.from(from);
+          }
 
-        @Override
-        public void recipient(String recipient) throws RejectException {
-          originalHandler.recipient(recipient);
-        }
+          @Override
+          public void recipient(String recipient) throws RejectException {
+            originalHandler.recipient(recipient);
+          }
 
-        @Override
-        public void data(InputStream data) throws RejectException, TooMuchDataException, IOException {
-          String dataString = TestUtils.inputStreamToString(data);
+          @Override
+          public void data(InputStream data) throws RejectException, TooMuchDataException, IOException {
+            String dataString = TestUtils.inputStreamToString(data);
 
-          List<Integer> bareLfIndexes = new ArrayList<>();
-          for(int i = 0; i< dataString.length(); i++){
-            if(dataString.charAt(i) == '\n'){
-              if(i == 0 || dataString.charAt(i-1) != '\r'){
-                bareLfIndexes.add(i);
+            List<Integer> bareLfIndexes = new ArrayList<>();
+            for (int i = 0; i < dataString.length(); i++) {
+              if (dataString.charAt(i) == '\n') {
+                if (i == 0 || dataString.charAt(i - 1) != '\r') {
+                  bareLfIndexes.add(i);
+                }
               }
             }
+
+            if (!bareLfIndexes.isEmpty()) {
+              throw new RejectException(String.format("bare <LF> received after DATA %s", bareLfIndexes));
+            }
+
+            InputStream stream = new ByteArrayInputStream(dataString.getBytes(StandardCharsets.UTF_8));
+            originalHandler.data(stream);
           }
 
-          if (!bareLfIndexes.isEmpty()) {
-            throw new RejectException(String.format("bare <LF> received after DATA %s", bareLfIndexes));
+          @Override
+          public void done() {
+            originalHandler.done();
           }
-
-          InputStream stream = new ByteArrayInputStream(dataString.getBytes(StandardCharsets.UTF_8));
-          originalHandler.data(stream);
-        }
-
-        @Override
-        public void done() {
-          originalHandler.done();
-        }
-      };
-    });
+        };
+      });
+    }
 
     wiser.getServer().setEnableTLS(true);
 

--- a/src/test/java/io/vertx/ext/mail/impl/SMTPSendMailTest.java
+++ b/src/test/java/io/vertx/ext/mail/impl/SMTPSendMailTest.java
@@ -1,0 +1,184 @@
+package io.vertx.ext.mail.impl;
+
+import io.vertx.core.Future;
+import io.vertx.core.impl.logging.Logger;
+import io.vertx.core.impl.logging.LoggerFactory;
+import io.vertx.ext.mail.*;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.mail.Address;
+import javax.mail.internet.MimeMessage;
+import java.util.ArrayList;
+import java.util.List;
+
+@RunWith(VertxUnitRunner.class)
+public class SMTPSendMailTest extends SMTPTestWiser {
+
+  private static final Logger log = LoggerFactory.getLogger(SMTPSendMailTest.class);
+
+  private final MailConfig config = configNoSSL();
+
+  @Override
+  protected void startSMTP(String factory) {
+    startSMTP(factory, true);
+  }
+
+  private String strRepeat(String s, int length) {
+    StringBuilder b = new StringBuilder();
+    for (int i = 0; i < length; i++) {
+      b.append(s);
+    }
+    return b.toString();
+  }
+
+  @Test
+  public void testBareLfDetectionFailing(TestContext testContext) {
+    this.testContext = testContext;
+
+    Async async = testContext.async();
+
+    SMTPConnectionPool pool = new SMTPConnectionPool(vertx, config);
+    pool.getConnection("hostname").onComplete(connectionResult -> {
+      SMTPConnection smtpConnection = connectionResult.result();
+
+      //smtpConnection.setExceptionHandler(log::info);
+      smtpConnection.write("AUTH PLAIN AHh4eAB5eXk=")
+        .flatMap(result -> {
+          log.info("Auth Response: " + result.getValue());
+          assertTrue(result.isStatusOk());
+          return Future.succeededFuture(result);
+        })
+        .flatMap(ignore -> smtpConnection.write("MAIL FROM: <from@example.com>"))
+        .flatMap(result -> {
+          log.info("MAIL FROM Response: " + result.getValue());
+          assertTrue(result.isStatusOk());
+          return Future.succeededFuture(result);
+        })
+        .flatMap(ignore -> smtpConnection.write("RCPT TO: <user@xample.com>"))
+        .flatMap(result -> {
+          log.info("RCPT TO Response: " + result.getValue());
+          assertTrue(result.isStatusOk());
+          return Future.succeededFuture(result);
+        })
+        .flatMap((ignore) -> smtpConnection.write("DATA"))
+        .flatMap(result -> {
+          log.info("DATA Response: " + result.getValue());
+          assertTrue(result.isStatusContinue());
+          return Future.succeededFuture(result);
+        })
+        .flatMap((ignore) -> smtpConnection.writeLineWithDrain("MIME-Version: 1.0\r\nMessage-ID: <msg.0815@bareLF>", true))
+        .flatMap((ignore) -> smtpConnection.writeLineWithDrain("Subject: BareLFDetection", true))
+        .flatMap((ignore) -> smtpConnection.writeLineWithDrain("From: from@example.com\r\nTo: user@example.com", true))
+        .flatMap((ignore) -> smtpConnection.writeLineWithDrain("Content-Type: text/plain; charset=utf-8\r\nContent-Transfer-Encoding: quoted-printable", true))
+        .flatMap((ignore) -> smtpConnection.writeLineWithDrain("", true))
+        .flatMap((ignore) -> smtpConnection.writeLineWithDrain("will send some bare `\\n` as LineEnding here \n", true))
+        .flatMap((ignore) -> smtpConnection.writeLineWithDrain("This should be invalid", true))
+        .flatMap((ignore) -> smtpConnection.write("."))
+        .flatMap(result -> {
+          log.info("DATA end Response: " + result.getValue());
+          assertFalse(result.isStatusOk());
+          return Future.succeededFuture(result);
+        })
+        .andThen((ignore) -> async.complete());
+    });
+  }
+
+  @Test
+  public void testBareLfDetectionSucceed(TestContext testContext) {
+    this.testContext = testContext;
+
+    Async async = testContext.async();
+
+    SMTPConnectionPool pool = new SMTPConnectionPool(vertx, config);
+    pool.getConnection("hostname").onComplete(connectionResult -> {
+      SMTPConnection smtpConnection = connectionResult.result();
+
+      //smtpConnection.setExceptionHandler(log::info);
+      smtpConnection.write("AUTH PLAIN AHh4eAB5eXk=")
+        .flatMap(result -> {
+          log.info("Auth Response: " + result.getValue());
+          assertTrue(result.isStatusOk());
+          return Future.succeededFuture(result);
+        })
+        .flatMap(ignore -> smtpConnection.write("MAIL FROM: <from@example.com>"))
+        .flatMap(result -> {
+          log.info("MAIL FROM Response: " + result.getValue());
+          assertTrue(result.isStatusOk());
+          return Future.succeededFuture(result);
+        })
+        .flatMap(ignore -> smtpConnection.write("RCPT TO: <user@xample.com>"))
+        .flatMap(result -> {
+          log.info("RCPT TO Response: " + result.getValue());
+          assertTrue(result.isStatusOk());
+          return Future.succeededFuture(result);
+        })
+        .flatMap((ignore) -> smtpConnection.write("DATA"))
+        .flatMap(result -> {
+          log.info("DATA Response: " + result.getValue());
+          assertTrue(result.isStatusContinue());
+          return Future.succeededFuture(result);
+        })
+        .flatMap((ignore) -> smtpConnection.writeLineWithDrain("MIME-Version: 1.0\r\nMessage-ID: <msg.0815.1@bareLF>", true))
+        .flatMap((ignore) -> smtpConnection.writeLineWithDrain("Subject: BareLFDetection", true))
+        .flatMap((ignore) -> smtpConnection.writeLineWithDrain("From: from@example.com\r\nTo: user@example.com", true))
+        .flatMap((ignore) -> smtpConnection.writeLineWithDrain("Content-Type: text/plain; charset=utf-8\r\nContent-Transfer-Encoding: quoted-printable", true))
+        .flatMap((ignore) -> smtpConnection.writeLineWithDrain("", true))
+        .flatMap((ignore) -> smtpConnection.writeLineWithDrain("will send some `\\r\\n` as LineEnding here \r\n", true))
+        .flatMap((ignore) -> smtpConnection.writeLineWithDrain("This should be ok for us", true))
+        .flatMap((ignore) -> smtpConnection.write("."))
+        .flatMap(result -> {
+          log.info("DATA end Response: " + result.getValue());
+          assertTrue(result.isStatusOk());
+          return Future.succeededFuture(result);
+        })
+        .andThen((ignore) -> async.complete());
+    });
+  }
+
+  @Test
+  public void testHugeEmail(TestContext testContext) {
+    int recipients = 32;
+    String domain = "example.com";
+
+    this.testContext = testContext;
+    MailClient mailClient = mailClientLogin();
+
+    final String subject = strRepeat("S", 1024);
+    final String text = strRepeat("1", 512) + "\n" +
+      strRepeat("2", 1024) + "\n" +
+      strRepeat("3", 2048) + "\n";
+
+    List<String> to = new ArrayList<>();
+    for (int i = 0; i < recipients; i++) {
+      to.add("user" + i + "@" + domain);
+    }
+
+    MailMessage message = exampleMessage()
+      .setSubject(subject)
+      .setText(text)
+      .setTo(to);
+
+    testSuccess(mailClient, message, () -> {
+      final MimeMessage mimeMessage = wiser.getMessages().get(0).getMimeMessage();
+      String rawSubject = mimeMessage.getHeader("Subject", null);
+      assertTrue("raw subject contains \\r\\n within the AutoWrapped text", rawSubject.contains("\r\n") && !rawSubject.endsWith("\r\n"));
+      assertEquals(subject, mimeMessage.getSubject());
+
+      String messageText = mimeMessage.getContent().toString();
+      assertTrue(messageText.endsWith("\r\n"));
+      assertEquals("message text contains \\r\\n 3 Times in AutoWrapped text", 3, messageText.split("\r\n").length);
+      assertEquals(text, messageText.replace("\r\n", "\n"));
+
+      String rawTo = mimeMessage.getHeader("To", null);
+      assertTrue("raw To contains \\r\\n within the AutoWrapped text", rawTo.contains("\r\n") && !rawTo.endsWith("\r\n"));
+      assertEquals(recipients, mimeMessage.getAllRecipients().length);
+      for (Address recipient : mimeMessage.getAllRecipients()) {
+        assertTrue(recipient.toString() + "is in original recipient list", to.contains(recipient.toString()));
+      }
+    });
+  }
+}


### PR DESCRIPTION
## Motivation:

fixes #219  SMTP Smuggling problems

## Additional References:

https://cr.yp.to/docs/smtplf.html
https://www.postfix.org/smtp-smuggling.html

## Solution:

Replace `\n` in Headers by `\r\n` before sending.

## Msg Dumps for Reference:

https://gist.github.com/cs8898/b740ee29206d5b9f7bee7c352d676086

## Test:

* [x] Tested with my Quarkus Project (Postfix 3.5.23)


