### PR TITLE
FIX#219: bare <LF> received after DATA (encoder)

### DIFF
--- a/src/main/java/io/vertx/ext/mail/mailencoder/Utils.java
+++ b/src/main/java/io/vertx/ext/mail/mailencoder/Utils.java
@@ -161,11 +161,29 @@ public class Utils {
         } else {
           String encChar = encodeUnicode(ch);
           int newColumn = column + encChar.length();
+          // https://datatracker.ietf.org/doc/html/rfc2047#section-2
+          // encoded-word = "=?" charset "?" encoding "?" encoded-text "?="
+          //
+          // An 'encoded-word' may not be more than 75 characters long, including
+          //   'charset', 'encoding', 'encoded-text', and delimiters.  If it is
+          //   desirable to encode more text than will fit in an 'encoded-word' of
+          //   75 characters, multiple 'encoded-word's (separated by CRLF SPACE) may
+          //   be used.
+          // [...]
+          // While there is no limit to the length of a multiple-line header
+          //   field, each line of a header field that contains one or more
+          //   'encoded-word's is limited to 76 characters.
+
+          // https://datatracker.ietf.org/doc/html/rfc5322#section-2.1.1
+          // There are two limits that this specification places on the number of
+          //   characters in a line.  Each line of characters MUST be no more than
+          //   998 characters, and SHOULD be no more than 78 characters, excluding
+          //   the CRLF.
           if (newColumn <= 74) {
             sb.append(encChar);
             column = newColumn;
           } else {
-            sb.append("?=\n =?UTF-8?Q?").append(encChar);
+            sb.append("?=\r\n =?UTF-8?Q?").append(encChar);
             column = 11 + encChar.length();
           }
         }
@@ -205,8 +223,13 @@ public class Utils {
         email = adr.getEmail();
         name = adr.getName();
       }
+      // https://datatracker.ietf.org/doc/html/rfc5322#section-2.1.1
+      // There are two limits that this specification places on the number of
+      //   characters in a line.  Each line of characters MUST be no more than
+      //   998 characters, and SHOULD be no more than 78 characters, excluding
+      //   the CRLF.
       if (index + email.length() >= 76) {
-        sb.append("\n ");
+        sb.append("\r\n ");
         index = 1;
       }
       sb.append(email);
@@ -223,7 +246,7 @@ public class Utils {
             fold = index + 12 + 1 + 2 >= 76;
           }
           if (fold) {
-            sb.append("\n ");
+            sb.append("\r\n ");
             index = 1;
             hadSpace = true;
           }
@@ -245,7 +268,7 @@ public class Utils {
         } else {
           boolean hadSpace = false;
           if (index + name.length() + 3 >= 76) {
-            sb.append("\n ");
+            sb.append("\r\n ");
             index = 1;
             hadSpace = true;
           }

--- a/src/test/java/io/vertx/ext/mail/AdditionalAsserts.java
+++ b/src/test/java/io/vertx/ext/mail/AdditionalAsserts.java
@@ -23,6 +23,6 @@ package io.vertx.ext.mail;
  * @author <a href="http://oss.lehmann.cx/">Alexander Lehmann</a>
  */
 @FunctionalInterface
-interface AdditionalAsserts {
+public interface AdditionalAsserts {
   void doAsserts() throws Exception;
 }

--- a/src/test/java/io/vertx/ext/mail/SMTPTestBareLfMessageHandlerFactory.java
+++ b/src/test/java/io/vertx/ext/mail/SMTPTestBareLfMessageHandlerFactory.java
@@ -44,7 +44,7 @@ public class SMTPTestBareLfMessageHandlerFactory implements MessageHandlerFactor
             if (i == 0 || dataString.charAt(i - 1) != '\r') {
               log.warn(
                 String.format("bare <LF> detected near \"%s\"",
-                  dataString.substring(Math.max(0, i-10), i+10)
+                  dataString.substring(Math.max(0, i-10), Math.min(dataString.length(), i+10))
                     .replaceAll("\n", "\\\\n")
                     .replaceAll("\r", "\\\\r"))
               );

--- a/src/test/java/io/vertx/ext/mail/SMTPTestBareLfMessageHandlerFactory.java
+++ b/src/test/java/io/vertx/ext/mail/SMTPTestBareLfMessageHandlerFactory.java
@@ -1,0 +1,70 @@
+package io.vertx.ext.mail;
+
+import io.vertx.core.impl.logging.Logger;
+import io.vertx.core.impl.logging.LoggerFactory;
+import org.subethamail.smtp.*;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+public class SMTPTestBareLfMessageHandlerFactory implements MessageHandlerFactory {
+
+  private static final Logger log = LoggerFactory.getLogger("SMTPTestBareLFMessageHandler");
+  private final MessageHandlerFactory originalFactory;
+  public SMTPTestBareLfMessageHandlerFactory(MessageHandlerFactory originalFactory) {
+    this.originalFactory = originalFactory;
+  }
+
+
+  @Override
+  public MessageHandler create(MessageContext ctx) {
+    final MessageHandler originalHandler = originalFactory.create(ctx);
+    return new MessageHandler() {
+      @Override
+      public void from(String from) throws RejectException {
+        originalHandler.from(from);
+      }
+
+      @Override
+      public void recipient(String recipient) throws RejectException {
+        originalHandler.recipient(recipient);
+      }
+
+      @Override
+      public void data(InputStream data) throws RejectException, TooMuchDataException, IOException {
+        String dataString = TestUtils.inputStreamToString(data);
+
+        List<Integer> bareLfIndexes = new ArrayList<>();
+        for (int i = 0; i < dataString.length(); i++) {
+          if (dataString.charAt(i) == '\n') {
+            if (i == 0 || dataString.charAt(i - 1) != '\r') {
+              log.warn(
+                String.format("bare <LF> detected near \"%s\"",
+                  dataString.substring(Math.max(0, i-10), i+10)
+                    .replaceAll("\n", "\\\\n")
+                    .replaceAll("\r", "\\\\r"))
+              );
+              bareLfIndexes.add(i);
+            }
+          }
+        }
+
+        if (!bareLfIndexes.isEmpty()) {
+          throw new RejectException(String.format("bare <LF> received after DATA %s", bareLfIndexes));
+        }
+
+        InputStream stream = new ByteArrayInputStream(dataString.getBytes(StandardCharsets.UTF_8));
+        originalHandler.data(stream);
+      }
+
+      @Override
+      public void done() {
+        originalHandler.done();
+      }
+    };
+  }
+}

--- a/src/test/java/io/vertx/ext/mail/SMTPTestWiser.java
+++ b/src/test/java/io/vertx/ext/mail/SMTPTestWiser.java
@@ -24,6 +24,7 @@ import javax.mail.internet.MimeMessage;
 
 import org.subethamail.smtp.AuthenticationHandler;
 import org.subethamail.smtp.AuthenticationHandlerFactory;
+import org.subethamail.smtp.MessageHandlerFactory;
 import org.subethamail.smtp.RejectException;
 import org.subethamail.wiser.Wiser;
 import org.subethamail.wiser.WiserMessage;
@@ -47,6 +48,10 @@ public class SMTPTestWiser extends SMTPTestBase {
   protected Wiser wiser;
 
   protected void startSMTP(String factory) {
+    startSMTP(factory, true);
+  }
+
+  protected void startSMTP(String factory, boolean bareLf) {
     wiser = new Wiser();
 
     wiser.setPort(1587);
@@ -79,6 +84,12 @@ public class SMTPTestWiser extends SMTPTestBase {
 
     Security.setProperty("ssl.SocketFactory.provider", factory);
     wiser.getServer().setEnableTLS(true);
+
+    if(bareLf){
+      MessageHandlerFactory originalFactory = wiser.getServer().getMessageHandlerFactory();
+      MessageHandlerFactory bareLfFactory = new SMTPTestBareLfMessageHandlerFactory(originalFactory);
+      wiser.getServer().setMessageHandlerFactory(bareLfFactory);
+    }
 
     wiser.start();
   }

--- a/src/test/java/io/vertx/ext/mail/impl/SMTPSendMailTest.java
+++ b/src/test/java/io/vertx/ext/mail/impl/SMTPSendMailTest.java
@@ -1,0 +1,276 @@
+package io.vertx.ext.mail.impl;
+
+import io.vertx.core.Future;
+import io.vertx.core.impl.logging.Logger;
+import io.vertx.core.impl.logging.LoggerFactory;
+import io.vertx.ext.mail.*;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.mail.Address;
+import javax.mail.internet.MimeMessage;
+import java.util.ArrayList;
+import java.util.List;
+
+@RunWith(VertxUnitRunner.class)
+public class SMTPSendMailTest extends SMTPTestWiser {
+
+  private static final Logger log = LoggerFactory.getLogger(SMTPSendMailTest.class);
+
+  private final MailConfig config = configNoSSL();
+
+  @Override
+  protected void startSMTP(String factory) {
+    startSMTP(factory, true);
+  }
+
+  private String strRepeat(String s, int length) {
+    StringBuilder b = new StringBuilder();
+    for (int i = 0; i < length; i++) {
+      b.append(s);
+    }
+    return b.toString();
+  }
+
+  @Test
+  public void testBareLfDetectionFailing(TestContext testContext) {
+    this.testContext = testContext;
+
+    Async async = testContext.async();
+
+    SMTPConnectionPool pool = new SMTPConnectionPool(vertx, config);
+    pool.getConnection("hostname").onComplete(connectionResult -> {
+      SMTPConnection smtpConnection = connectionResult.result();
+
+      //smtpConnection.setExceptionHandler(log::info);
+      smtpConnection.write("AUTH PLAIN AHh4eAB5eXk=")
+        .flatMap(result -> {
+          log.info("Auth Response: " + result.getValue());
+          assertTrue(result.isStatusOk());
+          return Future.succeededFuture(result);
+        })
+        .flatMap(ignore -> smtpConnection.write("MAIL FROM: <from@example.com>"))
+        .flatMap(result -> {
+          log.info("MAIL FROM Response: " + result.getValue());
+          assertTrue(result.isStatusOk());
+          return Future.succeededFuture(result);
+        })
+        .flatMap(ignore -> smtpConnection.write("RCPT TO: <user@xample.com>"))
+        .flatMap(result -> {
+          log.info("RCPT TO Response: " + result.getValue());
+          assertTrue(result.isStatusOk());
+          return Future.succeededFuture(result);
+        })
+        .flatMap((ignore) -> smtpConnection.write("DATA"))
+        .flatMap(result -> {
+          log.info("DATA Response: " + result.getValue());
+          assertTrue(result.isStatusContinue());
+          return Future.succeededFuture(result);
+        })
+        .flatMap((ignore) -> smtpConnection.writeLineWithDrain("MIME-Version: 1.0\r\nMessage-ID: <msg.0815@bareLF>", true))
+        .flatMap((ignore) -> smtpConnection.writeLineWithDrain("Subject: BareLFDetection", true))
+        .flatMap((ignore) -> smtpConnection.writeLineWithDrain("From: from@example.com\r\nTo: user@example.com", true))
+        .flatMap((ignore) -> smtpConnection.writeLineWithDrain("Content-Type: text/plain; charset=utf-8\r\nContent-Transfer-Encoding: quoted-printable", true))
+        .flatMap((ignore) -> smtpConnection.writeLineWithDrain("", true))
+        .flatMap((ignore) -> smtpConnection.writeLineWithDrain("will send some bare `\\n` as LineEnding here \n", true))
+        .flatMap((ignore) -> smtpConnection.writeLineWithDrain("This should be invalid", true))
+        .flatMap((ignore) -> smtpConnection.write("."))
+        .flatMap(result -> {
+          log.info("DATA end Response: " + result.getValue());
+          assertFalse(result.isStatusOk());
+          return Future.succeededFuture(result);
+        })
+        .andThen((ignore) -> async.complete());
+    });
+  }
+
+  @Test
+  public void testBareLfDetectionSucceed(TestContext testContext) {
+    this.testContext = testContext;
+
+    Async async = testContext.async();
+
+    SMTPConnectionPool pool = new SMTPConnectionPool(vertx, config);
+    pool.getConnection("hostname").onComplete(connectionResult -> {
+      SMTPConnection smtpConnection = connectionResult.result();
+
+      //smtpConnection.setExceptionHandler(log::info);
+      smtpConnection.write("AUTH PLAIN AHh4eAB5eXk=")
+        .flatMap(result -> {
+          log.info("Auth Response: " + result.getValue());
+          assertTrue(result.isStatusOk());
+          return Future.succeededFuture(result);
+        })
+        .flatMap(ignore -> smtpConnection.write("MAIL FROM: <from@example.com>"))
+        .flatMap(result -> {
+          log.info("MAIL FROM Response: " + result.getValue());
+          assertTrue(result.isStatusOk());
+          return Future.succeededFuture(result);
+        })
+        .flatMap(ignore -> smtpConnection.write("RCPT TO: <user@xample.com>"))
+        .flatMap(result -> {
+          log.info("RCPT TO Response: " + result.getValue());
+          assertTrue(result.isStatusOk());
+          return Future.succeededFuture(result);
+        })
+        .flatMap((ignore) -> smtpConnection.write("DATA"))
+        .flatMap(result -> {
+          log.info("DATA Response: " + result.getValue());
+          assertTrue(result.isStatusContinue());
+          return Future.succeededFuture(result);
+        })
+        .flatMap((ignore) -> smtpConnection.writeLineWithDrain("MIME-Version: 1.0\r\nMessage-ID: <msg.0815.1@bareLF>", true))
+        .flatMap((ignore) -> smtpConnection.writeLineWithDrain("Subject: BareLFDetection", true))
+        .flatMap((ignore) -> smtpConnection.writeLineWithDrain("From: from@example.com\r\nTo: user@example.com", true))
+        .flatMap((ignore) -> smtpConnection.writeLineWithDrain("Content-Type: text/plain; charset=utf-8\r\nContent-Transfer-Encoding: quoted-printable", true))
+        .flatMap((ignore) -> smtpConnection.writeLineWithDrain("", true))
+        .flatMap((ignore) -> smtpConnection.writeLineWithDrain("will send some `\\r\\n` as LineEnding here \r\n", true))
+        .flatMap((ignore) -> smtpConnection.writeLineWithDrain("This should be ok for us", true))
+        .flatMap((ignore) -> smtpConnection.write("."))
+        .flatMap(result -> {
+          log.info("DATA end Response: " + result.getValue());
+          assertTrue(result.isStatusOk());
+          return Future.succeededFuture(result);
+        })
+        .andThen((ignore) -> async.complete());
+    });
+  }
+
+  @Test
+  public void testLongRecepientList(TestContext testContext) {
+    int recipients = 32;
+    String domain = "example.com";
+    final String subject = "testLongRecepientList";
+    final String text = "Hello testLongRecepientList!";
+
+    this.testContext = testContext;
+    MailClient mailClient = mailClientLogin();
+
+    List<String> to = new ArrayList<>();
+    for (int i = 0; i < recipients; i++) {
+      to.add("user" + i + "@" + domain);
+    }
+
+    MailMessage message = exampleMessage()
+      .setSubject(subject)
+      .setText(text)
+      .setTo(to);
+
+    testSuccess(mailClient, message, () -> {
+      final MimeMessage mimeMessage = wiser.getMessages().get(0).getMimeMessage();
+      String rawSubject = mimeMessage.getHeader("Subject", null);
+      assertEquals("raw Subject is not Wrapped", subject, rawSubject);
+
+      String rawTo = mimeMessage.getHeader("To", null);
+      assertTrue("raw To contains \\r\\n within the AutoWrapped text", rawTo.contains("\r\n") && !rawTo.endsWith("\r\n"));
+    });
+  }
+
+  @Test
+  public void testLongRecepientName(TestContext testContext) {
+    String domain = "example.com";
+    final String subject = "testLongRecepientList";
+    final String text = "Hello testLongRecepientList!";
+    final String toName = strRepeat("U", 1024);
+    final String to = "\""+toName+"\" <user@"+domain+">";
+
+    this.testContext = testContext;
+    MailClient mailClient = mailClientLogin();
+
+    MailMessage message = exampleMessage()
+      .setSubject(subject)
+      .setText(text)
+      .setTo(to);
+
+    testSuccess(mailClient, message, () -> {
+      final MimeMessage mimeMessage = wiser.getMessages().get(0).getMimeMessage();
+      String rawSubject = mimeMessage.getHeader("Subject", null);
+      assertEquals("raw Subject is not Wrapped", subject, rawSubject);
+
+      String rawTo = mimeMessage.getHeader("To", null);
+      assertTrue("raw To contains \\r\\n within the AutoWrapped text", rawTo.contains("\r\n") && !rawTo.endsWith("\r\n"));
+    });
+  }
+
+  @Test
+  public void testUtfLongMsg(TestContext testContext) {
+    int recipients = 1;
+    String domain = "example.com";
+
+    this.testContext = testContext;
+    MailClient mailClient = mailClientLogin();
+
+    final String subject = "testUtfLongMsg";
+    final String text = strRepeat("ä", 512) + "\n" +
+      strRepeat("ö", 1024) + "\n" +
+      strRepeat("ü", 2048) + "\n";
+
+    List<String> to = new ArrayList<>();
+    for (int i = 0; i < recipients; i++) {
+      to.add("user" + i + "@" + domain);
+    }
+
+
+    MailMessage message = exampleMessage()
+      .setSubject(subject)
+      .setText(text)
+      .setTo(to);
+
+    testSuccess(mailClient, message, () -> {
+      final MimeMessage mimeMessage = wiser.getMessages().get(0).getMimeMessage();
+      String rawSubject = mimeMessage.getHeader("Subject", null);
+      assertEquals("raw Subject is not Wrapped", subject, rawSubject);
+
+      String messageText = mimeMessage.getContent().toString();
+      assertTrue(messageText.endsWith("\r\n"));
+      assertEquals("message text contains \\r\\n 3 Times in AutoWrapped text", 3, messageText.split("\r\n").length);
+      assertEquals(text, messageText.replace("\r\n", "\n"));
+    });
+  }
+
+  @Test
+  public void testHugeEmail(TestContext testContext) {
+    int recipients = 32;
+    String domain = "example.com";
+
+    this.testContext = testContext;
+    MailClient mailClient = mailClientLogin();
+
+    final String subject = strRepeat("S", 1024);
+    final String text = strRepeat("1", 512) + "\n" +
+      strRepeat("2", 1024) + "\n" +
+      strRepeat("3", 2048) + "\n";
+
+    List<String> to = new ArrayList<>();
+    for (int i = 0; i < recipients; i++) {
+      to.add("user" + i + "@" + domain);
+    }
+
+    MailMessage message = exampleMessage()
+      .setSubject(subject)
+      .setText(text)
+      .setTo(to);
+
+    testSuccess(mailClient, message, () -> {
+      final MimeMessage mimeMessage = wiser.getMessages().get(0).getMimeMessage();
+      String rawSubject = mimeMessage.getHeader("Subject", null);
+      assertTrue("raw subject contains \\r\\n within the AutoWrapped text", rawSubject.contains("\r\n") && !rawSubject.endsWith("\r\n"));
+      assertEquals(subject, mimeMessage.getSubject());
+
+      String messageText = mimeMessage.getContent().toString();
+      assertTrue(messageText.endsWith("\r\n"));
+      assertEquals("message text contains \\r\\n 3 Times in AutoWrapped text", 3, messageText.split("\r\n").length);
+      assertEquals(text, messageText.replace("\r\n", "\n"));
+
+      String rawTo = mimeMessage.getHeader("To", null);
+      assertTrue("raw To contains \\r\\n within the AutoWrapped text", rawTo.contains("\r\n") && !rawTo.endsWith("\r\n"));
+      assertEquals(recipients, mimeMessage.getAllRecipients().length);
+      for (Address recipient : mimeMessage.getAllRecipients()) {
+        assertTrue(recipient.toString() + "is in original recipient list", to.contains(recipient.toString()));
+      }
+    });
+  }
+}

--- a/src/test/java/io/vertx/ext/mail/impl/SMTPSendMailTest.java
+++ b/src/test/java/io/vertx/ext/mail/impl/SMTPSendMailTest.java
@@ -196,6 +196,32 @@ public class SMTPSendMailTest extends SMTPTestWiser {
   }
 
   @Test
+  public void testLongFromName(TestContext testContext) {
+    String domain = "example.com";
+    final String subject = "testLongRecepientList";
+    final String text = "Hello testLongRecepientList!";
+    final String toName = strRepeat("U", 1024);
+    final String from = "\""+toName+"\" <user@"+domain+">";
+
+    this.testContext = testContext;
+    MailClient mailClient = mailClientLogin();
+
+    MailMessage message = exampleMessage()
+      .setSubject(subject)
+      .setText(text)
+      .setFrom(from);
+
+    testSuccess(mailClient, message, () -> {
+      final MimeMessage mimeMessage = wiser.getMessages().get(0).getMimeMessage();
+      String rawSubject = mimeMessage.getHeader("Subject", null);
+      assertEquals("raw Subject is not Wrapped", subject, rawSubject);
+
+      String rawFrom = mimeMessage.getHeader("From", null);
+      assertTrue("raw To contains \\r\\n within the AutoWrapped text", rawFrom.contains("\r\n") && !rawFrom.endsWith("\r\n"));
+    });
+  }
+
+  @Test
   public void testUtfLongMsg(TestContext testContext) {
     int recipients = 1;
     String domain = "example.com";

--- a/src/test/java/io/vertx/ext/mail/mailencoder/MailEncoderTest.java
+++ b/src/test/java/io/vertx/ext/mail/mailencoder/MailEncoderTest.java
@@ -158,11 +158,11 @@ public class MailEncoderTest {
     }
     message.setTo(to);
     String mime = new MailEncoder(message, HOSTNAME).encode();
-    assertThat(mime, containsString("To: user0@example.com,user1@example.com,user2@example.com,user3@example.com,\n"
-      + " user4@example.com,user5@example.com,user6@example.com,user7@example.com,\n"
-      + " user8@example.com,user9@example.com,user10@example.com,user11@example.com,\n"
-      + " user12@example.com,user13@example.com,user14@example.com,\n"
-      + " user15@example.com,user16@example.com,user17@example.com,\n"
+    assertThat(mime, containsString("To: user0@example.com,user1@example.com,user2@example.com,user3@example.com,\r\n"
+      + " user4@example.com,user5@example.com,user6@example.com,user7@example.com,\r\n"
+      + " user8@example.com,user9@example.com,user10@example.com,user11@example.com,\r\n"
+      + " user12@example.com,user13@example.com,user14@example.com,\r\n"
+      + " user15@example.com,user16@example.com,user17@example.com,\r\n"
       + " user18@example.com,user19@example.com\n"));
 
     assertEquals(
@@ -179,18 +179,18 @@ public class MailEncoderTest {
     }
     message.setTo(to);
     String mime = new MailEncoder(message, HOSTNAME).encode();
-    assertThat(mime, containsString("To: user0@example.com (Some User Name),user1@example.com\n"
-      + " (Some User Name),user2@example.com (Some User Name),\n"
-      + " user3@example.com (Some User Name),user4@example.com (Some User Name),\n"
-      + " user5@example.com (Some User Name),user6@example.com (Some User Name),\n"
-      + " user7@example.com (Some User Name),user8@example.com (Some User Name),\n"
-      + " user9@example.com (Some User Name),user10@example.com\n"
-      + " (Some User Name),user11@example.com (Some User Name),\n"
-      + " user12@example.com (Some User Name),user13@example.com\n"
-      + " (Some User Name),user14@example.com (Some User Name),\n"
-      + " user15@example.com (Some User Name),user16@example.com\n"
-      + " (Some User Name),user17@example.com (Some User Name),\n"
-      + " user18@example.com (Some User Name),user19@example.com\n" + " (Some User Name)\n"));
+    assertThat(mime, containsString("To: user0@example.com (Some User Name),user1@example.com\r\n"
+      + " (Some User Name),user2@example.com (Some User Name),\r\n"
+      + " user3@example.com (Some User Name),user4@example.com (Some User Name),\r\n"
+      + " user5@example.com (Some User Name),user6@example.com (Some User Name),\r\n"
+      + " user7@example.com (Some User Name),user8@example.com (Some User Name),\r\n"
+      + " user9@example.com (Some User Name),user10@example.com\r\n"
+      + " (Some User Name),user11@example.com (Some User Name),\r\n"
+      + " user12@example.com (Some User Name),user13@example.com\r\n"
+      + " (Some User Name),user14@example.com (Some User Name),\r\n"
+      + " user15@example.com (Some User Name),user16@example.com\r\n"
+      + " (Some User Name),user17@example.com (Some User Name),\r\n"
+      + " user18@example.com (Some User Name),user19@example.com\r\n" + " (Some User Name)\n"));
 
     assertEquals(
         "[Some User Name <user0@example.com>, Some User Name <user1@example.com>, Some User Name <user2@example.com>, Some User Name <user3@example.com>, Some User Name <user4@example.com>, Some User Name <user5@example.com>, Some User Name <user6@example.com>, Some User Name <user7@example.com>, Some User Name <user8@example.com>, Some User Name <user9@example.com>, Some User Name <user10@example.com>, Some User Name <user11@example.com>, Some User Name <user12@example.com>, Some User Name <user13@example.com>, Some User Name <user14@example.com>, Some User Name <user15@example.com>, Some User Name <user16@example.com>, Some User Name <user17@example.com>, Some User Name <user18@example.com>, Some User Name <user19@example.com>]",
@@ -206,19 +206,19 @@ public class MailEncoderTest {
     }
     message.setTo(to);
     String mime = new MailEncoder(message, HOSTNAME).encode();
-    assertThat(mime, containsString("To: user0@example.com (=?UTF-8?Q?=C3=84a?=),user1@example.com\n"
-      + " (=?UTF-8?Q?=C3=84a?=),user2@example.com (=?UTF-8?Q?=C3=84a?=),\n"
-      + " user3@example.com (=?UTF-8?Q?=C3=84a?=),user4@example.com\n"
-      + " (=?UTF-8?Q?=C3=84a?=),user5@example.com (=?UTF-8?Q?=C3=84a?=),\n"
-      + " user6@example.com (=?UTF-8?Q?=C3=84a?=),user7@example.com\n"
-      + " (=?UTF-8?Q?=C3=84a?=),user8@example.com (=?UTF-8?Q?=C3=84a?=),\n"
-      + " user9@example.com (=?UTF-8?Q?=C3=84a?=),user10@example.com\n"
-      + " (=?UTF-8?Q?=C3=84a?=),user11@example.com (=?UTF-8?Q?=C3=84a?=),\n"
-      + " user12@example.com (=?UTF-8?Q?=C3=84a?=),user13@example.com\n"
-      + " (=?UTF-8?Q?=C3=84a?=),user14@example.com (=?UTF-8?Q?=C3=84a?=),\n"
-      + " user15@example.com (=?UTF-8?Q?=C3=84a?=),user16@example.com\n"
-      + " (=?UTF-8?Q?=C3=84a?=),user17@example.com (=?UTF-8?Q?=C3=84a?=),\n"
-      + " user18@example.com (=?UTF-8?Q?=C3=84a?=),user19@example.com\n" + " (=?UTF-8?Q?=C3=84a?=)\n"));
+    assertThat(mime, containsString("To: user0@example.com (=?UTF-8?Q?=C3=84a?=),user1@example.com\r\n"
+      + " (=?UTF-8?Q?=C3=84a?=),user2@example.com (=?UTF-8?Q?=C3=84a?=),\r\n"
+      + " user3@example.com (=?UTF-8?Q?=C3=84a?=),user4@example.com\r\n"
+      + " (=?UTF-8?Q?=C3=84a?=),user5@example.com (=?UTF-8?Q?=C3=84a?=),\r\n"
+      + " user6@example.com (=?UTF-8?Q?=C3=84a?=),user7@example.com\r\n"
+      + " (=?UTF-8?Q?=C3=84a?=),user8@example.com (=?UTF-8?Q?=C3=84a?=),\r\n"
+      + " user9@example.com (=?UTF-8?Q?=C3=84a?=),user10@example.com\r\n"
+      + " (=?UTF-8?Q?=C3=84a?=),user11@example.com (=?UTF-8?Q?=C3=84a?=),\r\n"
+      + " user12@example.com (=?UTF-8?Q?=C3=84a?=),user13@example.com\r\n"
+      + " (=?UTF-8?Q?=C3=84a?=),user14@example.com (=?UTF-8?Q?=C3=84a?=),\r\n"
+      + " user15@example.com (=?UTF-8?Q?=C3=84a?=),user16@example.com\r\n"
+      + " (=?UTF-8?Q?=C3=84a?=),user17@example.com (=?UTF-8?Q?=C3=84a?=),\r\n"
+      + " user18@example.com (=?UTF-8?Q?=C3=84a?=),user19@example.com\r\n" + " (=?UTF-8?Q?=C3=84a?=)\n"));
   }
 
   @Test
@@ -229,7 +229,7 @@ public class MailEncoderTest {
     String mime = new MailEncoder(message, HOSTNAME).encode();
     assertThat(
       mime,
-      containsString("To: user@example.com\n"
+      containsString("To: user@example.com\r\n"
         + " (this email has an insanely long username just to check that the text is correctly wrapped into multiple lines)\n"));
   }
 
@@ -238,11 +238,11 @@ public class MailEncoderTest {
     MailMessage message = new MailMessage();
 
     String[] expected1 = {
-      "To: 0123456789012345678901234567890123456789@me.com (=?UTF-8?Q?=E6=88=91a?=)\n",
+      "To: 0123456789012345678901234567890123456789@me.com (=?UTF-8?Q?=E6=88=91a?=)\n", // MailEncoder joins lines by \n
       "To: 0123456789012345678901234567890123456789x@me.com (=?UTF-8?Q?=E6=88=91a?=)\n",
-      "To: 0123456789012345678901234567890123456789xx@me.com\n (=?UTF-8?Q?=E6=88=91a?=)",
-      "To: 0123456789012345678901234567890123456789xxx@me.com\n (=?UTF-8?Q?=E6=88=91a?=)",
-      "To: 0123456789012345678901234567890123456789xxxx@me.com\n (=?UTF-8?Q?=E6=88=91a?=)"
+      "To: 0123456789012345678901234567890123456789xx@me.com\r\n (=?UTF-8?Q?=E6=88=91a?=)",
+      "To: 0123456789012345678901234567890123456789xxx@me.com\r\n (=?UTF-8?Q?=E6=88=91a?=)",
+      "To: 0123456789012345678901234567890123456789xxxx@me.com\r\n (=?UTF-8?Q?=E6=88=91a?=)"
     };
     StringBuilder emailHeader = new StringBuilder("0123456789012345678901234567890123456789");
     for (int i = 0; i < 5; i++) {
@@ -255,11 +255,11 @@ public class MailEncoderTest {
     }
 
     String[] expected2 = {
-      "To: 01234567890123456789012345678901234567890123456@me.com (=?UTF-8?Q?a?=\n =?UTF-8?Q?=E6=88=91?=)",
-      "To: 01234567890123456789012345678901234567890123456x@me.com (=?UTF-8?Q?a?=\n =?UTF-8?Q?=E6=88=91?=)",
-      "To: 01234567890123456789012345678901234567890123456xx@me.com (=?UTF-8?Q?a?=\n =?UTF-8?Q?=E6=88=91?=)",
-      "To: 01234567890123456789012345678901234567890123456xxx@me.com\n (=?UTF-8?Q?a=E6=88=91?=)",
-      "To: 01234567890123456789012345678901234567890123456xxxx@me.com\n (=?UTF-8?Q?a=E6=88=91?=)"
+      "To: 01234567890123456789012345678901234567890123456@me.com (=?UTF-8?Q?a?=\r\n =?UTF-8?Q?=E6=88=91?=)",
+      "To: 01234567890123456789012345678901234567890123456x@me.com (=?UTF-8?Q?a?=\r\n =?UTF-8?Q?=E6=88=91?=)",
+      "To: 01234567890123456789012345678901234567890123456xx@me.com (=?UTF-8?Q?a?=\r\n =?UTF-8?Q?=E6=88=91?=)",
+      "To: 01234567890123456789012345678901234567890123456xxx@me.com\r\n (=?UTF-8?Q?a=E6=88=91?=)",
+      "To: 01234567890123456789012345678901234567890123456xxxx@me.com\r\n (=?UTF-8?Q?a=E6=88=91?=)"
     };
     emailHeader = new StringBuilder("01234567890123456789012345678901234567890123456");
     for (int i = 0; i < 5; i++) {
@@ -278,8 +278,8 @@ public class MailEncoderTest {
     message
       .setTo("user@example.com (ä this email has an insanely long username just to check that the text is correctly wrapped into multiple lines)");
     String mime = new MailEncoder(message, HOSTNAME).encode();
-    assertThat(mime, containsString("To: user@example.com (=?UTF-8?Q?=C3=A4_this_email_has_an_insanely_long_use?=\n"
-      + " =?UTF-8?Q?rname_just_to_check_that_the_text_is_correctly_wrapped_into_mul?=\n"
+    assertThat(mime, containsString("To: user@example.com (=?UTF-8?Q?=C3=A4_this_email_has_an_insanely_long_use?=\r\n"
+      + " =?UTF-8?Q?rname_just_to_check_that_the_text_is_correctly_wrapped_into_mul?=\r\n"
       + " =?UTF-8?Q?tiple_lines?=)\n"));
   }
 
@@ -345,10 +345,10 @@ public class MailEncoderTest {
   public void testSubjectEncodedLong() throws Exception {
     MailMessage message = new MailMessage();
     final String subject = "ä=======================================================================================";
-    final String encodedSubject = "Subject: =?UTF-8?Q?=C3=A4=3D=3D=3D=3D=3D=3D=3D=3D=3D=3D=3D=3D=3D=3D=3D=3D?=\n"
-      + " =?UTF-8?Q?=3D=3D=3D=3D=3D=3D=3D=3D=3D=3D=3D=3D=3D=3D=3D=3D=3D=3D=3D=3D=3D?=\n"
-      + " =?UTF-8?Q?=3D=3D=3D=3D=3D=3D=3D=3D=3D=3D=3D=3D=3D=3D=3D=3D=3D=3D=3D=3D=3D?=\n"
-      + " =?UTF-8?Q?=3D=3D=3D=3D=3D=3D=3D=3D=3D=3D=3D=3D=3D=3D=3D=3D=3D=3D=3D=3D=3D?=\n"
+    final String encodedSubject = "Subject: =?UTF-8?Q?=C3=A4=3D=3D=3D=3D=3D=3D=3D=3D=3D=3D=3D=3D=3D=3D=3D=3D?=\r\n"
+      + " =?UTF-8?Q?=3D=3D=3D=3D=3D=3D=3D=3D=3D=3D=3D=3D=3D=3D=3D=3D=3D=3D=3D=3D=3D?=\r\n"
+      + " =?UTF-8?Q?=3D=3D=3D=3D=3D=3D=3D=3D=3D=3D=3D=3D=3D=3D=3D=3D=3D=3D=3D=3D=3D?=\r\n"
+      + " =?UTF-8?Q?=3D=3D=3D=3D=3D=3D=3D=3D=3D=3D=3D=3D=3D=3D=3D=3D=3D=3D=3D=3D=3D?=\r\n"
       + " =?UTF-8?Q?=3D=3D=3D=3D=3D=3D=3D=3D?=";
     message.setSubject(subject);
     String mime = new MailEncoder(message, HOSTNAME).encode();
@@ -360,7 +360,7 @@ public class MailEncoderTest {
   public void testSubjectEncodedLong2() throws Exception {
     MailMessage message = new MailMessage();
     final String subject = "ä****************************************************************************************************************";
-    final String encodedSubject = "Subject: =?UTF-8?Q?=C3=A4*************************************************?=\n"
+    final String encodedSubject = "Subject: =?UTF-8?Q?=C3=A4*************************************************?=\r\n"
       + " =?UTF-8?Q?***************************************************************?=\n";
     message.setSubject(subject);
     String mime = new MailEncoder(message, HOSTNAME).encode();


### PR DESCRIPTION
Motivation:

fixes https://github.com/vert-x3/vertx-mail-client/issues/219 SMTP Smuggling problems

Replaces #220

Implementation Detail:

* As discussed in #219 the preferred way is to fix the Encoder instead of Replacing it in the SMTP Client.
This PR implements the required changes in the Encoder.

* The BareLF check is implemented as Wiser MessageHandler (as it was in #220)

* The error mainly occures in the header-section, so the test will set `Subject`, `From` and `To` to verify correct handling.

* Due to the changes in the Encoder, the MailEncoderTest has to be fixed, consider that `\r\n` is only introduced in length dependent breaking of the encoded words in [Utils.java](https://github.com/cs8898/vertx-mail-client/blob/fix/219-bare-LF-encoder/src/main/java/io/vertx/ext/mail/mailencoder/Utils.java). The encoded mail as `EncodedPart` will be concatenated by `\n` in  `MailEncoder.encode()` [MailEncoder.java#L104-L106](https://github.com/cs8898/vertx-mail-client/blob/7420ae3834b5b8b24ccbff34926c60a700e00a61/src/main/java/io/vertx/ext/mail/mailencoder/MailEncoder.java#L104-L106) (only used in tests) and [EncodedPart.java#L35-L45](https://github.com/cs8898/vertx-mail-client/blob/fix/219-bare-LF-encoder/src/main/java/io/vertx/ext/mail/mailencoder/EncodedPart.java#L35-L45)
