### PR TITLE
Add password supplier functionality to MailConfig (5.x)

### DIFF
--- a/src/main/java/io/vertx/ext/mail/MailConfig.java
+++ b/src/main/java/io/vertx/ext/mail/MailConfig.java
@@ -28,6 +28,7 @@ import io.vertx.core.net.SSLEngineOptions;
 import io.vertx.core.net.TrustOptions;
 
 import java.util.*;
+import java.util.function.*;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -74,6 +75,7 @@ public class MailConfig extends NetClientOptions {
   private String authMethods;
   private String username;
   private String password;
+  private Function<MailConfig, String> passwordSupplier;
   private String ownHostname;
   private int maxPoolSize = DEFAULT_MAX_POOL_SIZE;
   private boolean keepAlive = DEFAULT_KEEP_ALIVE;
@@ -151,6 +153,7 @@ public class MailConfig extends NetClientOptions {
     login = other.login;
     username = other.username;
     password = other.password;
+    passwordSupplier = other.passwordSupplier;
     authMethods = other.authMethods;
     ownHostname = other.ownHostname;
     maxPoolSize = other.maxPoolSize;
@@ -519,6 +522,9 @@ public class MailConfig extends NetClientOptions {
    * @return password
    */
   public String getPassword() {
+    if (passwordSupplier != null) {
+      return passwordSupplier.apply(this);
+    }
     return password;
   }
 
@@ -531,6 +537,15 @@ public class MailConfig extends NetClientOptions {
   public MailConfig setPassword(String password) {
     this.password = password;
     return this;
+  }
+
+  /**
+   * Set the password supplier function.
+   *
+   * @return the password supplier function
+   */
+  public void setPasswordSupplier(Function<MailConfig, String> passwordSupplier) {
+    this.passwordSupplier = passwordSupplier;
   }
 
   // Maintain compatibility of return type

--- a/src/test/java/io/vertx/tests/mail/client/MailConfigTest.java
+++ b/src/test/java/io/vertx/tests/mail/client/MailConfigTest.java
@@ -208,6 +208,14 @@ public class MailConfigTest {
     mailConfig.setPassword("secret");
     assertEquals("secret", mailConfig.getPassword());
   }
+  
+  @Test
+  public void testPasswordSupplier() {
+    MailConfig mailConfig = new MailConfig();
+    mailConfig.setPassword("secret2");
+    mailConfig.setPasswordSupplier(config -> "secret");
+    assertEquals("secret", mailConfig.getPassword());
+  }
 
   @Test
   public void testTrustAll() {


### PR DESCRIPTION
Motivation:

Your PR introduces a passwordSupplier field to the MailConfig class, allowing the password to be provided dynamically via a Function<MailConfig, String>. This is particularly useful for XOAUTH2 authentication, where the access token (used as the password) may need to be refreshed periodically. Instead of requiring the user to update the password property directly, the mail client can now request the current password or token on demand by invoking the supplier.  This makes it possible to block the new SMTP connection until the token is refreshed on-demand, which is not possible otherwise.

Discussion which triggered this pull request:
https://github.com/quarkusio/quarkus/issues/39359
