### PR TITLE
Add possibility to create a main client with an additional access tok…

### DIFF
--- a/src/main/java/io/vertx/ext/mail/MailClient.java
+++ b/src/main/java/io/vertx/ext/mail/MailClient.java
@@ -21,6 +21,7 @@ import io.vertx.core.*;
 import io.vertx.ext.mail.impl.MailClientImpl;
 
 import java.util.UUID;
+import java.util.function.Function;
 
 /**
  * SMTP mail client for Vert.x
@@ -59,6 +60,26 @@ public interface MailClient {
    */
   static MailClient createShared(Vertx vertx, MailConfig config, String poolName) {
     return new MailClientImpl(vertx, config, poolName);
+  }
+
+
+  /**
+   * Create a Mail client which shares its connection pool with any other Mail clients created with the same
+   * pool name. The access token provider function will be called for each connection to get the current 
+   * access token.
+   *
+   * @param vertx  the Vert.x instance
+   * @param config  the configuration
+   * @param poolName  the pool name
+   * @param accessTokenProvider  a function which provides the access token for the given MailConfig
+   * @return the client
+   */
+  static MailClient createSharedXOAuthClient(
+      Vertx vertx,
+      MailConfig config,
+      String poolName,
+      Function<MailConfig, String> accessTokenProvider) {
+    return new MailClientImpl(vertx, config, poolName, accessTokenProvider);
   }
 
   /**

--- a/src/main/java/io/vertx/ext/mail/impl/SMTPAuthentication.java
+++ b/src/main/java/io/vertx/ext/mail/impl/SMTPAuthentication.java
@@ -57,8 +57,7 @@ class SMTPAuthentication {
   public Future<Void> start() {
     List<String> auths = intersectAllowedMethods();
     final boolean foundAllowedMethods = !auths.isEmpty();
-    if (config.getLogin() != LoginOption.DISABLED && config.getUsername() != null && config.getPassword() != null
-      && foundAllowedMethods) {
+    if ( authOperationFactory.isLoginConfigured(config) && foundAllowedMethods) {
       authCmd(auths);
     } else {
       if (config.getLogin() == LoginOption.REQUIRED) {


### PR DESCRIPTION
Motivation:

PR introduces a passwordSupplier when creating the mail client, allowing the password to be provided dynamically via a Function<MailConfig, String>. This is particularly useful for XOAUTH2 authentication, where the access token (used as the password) may need to be refreshed periodically. Instead of requiring the user to update the password property directly, the mail client can now request the current password or token on demand by invoking the supplier. This makes it possible to block the new SMTP connection until the token is refreshed on-demand, which is not possible otherwise.

Discussion which triggered this pull request:
https://github.com/quarkusio/quarkus/issues/39359

This is an alternative approach to #231.