### PR TITLE
Support rotating credentials

### DIFF
--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -65,6 +65,19 @@ A more elaborate example using a mailserver that requires login via TLS
 {@link examples.MailExamples#createClient2}
 ----
 
+=== Dynamic credentials configuration
+
+You can configure credentials using a Java supplier in {@link io.vertx.ext.mail.MailClientBuilder} instead of properties of the {@link io.vertx.ext.mail.MailConfig}.
+
+Since the supplier is asynchronous, it can be used to provide dynamic pool configuration (e.g. password rotation).
+
+[source,$lang]
+----
+{@link examples.MailExamples#dynamicCredentials}
+----
+
+NOTE: When a credentials supplier is provided, username and password set in {@link io.vertx.ext.mail.MailConfig} get ignored.
+
 == Sending mails
 
 Once the client object is created, you can use it to send mails. Since the

--- a/src/main/java/examples/MailExamples.java
+++ b/src/main/java/examples/MailExamples.java
@@ -16,9 +16,11 @@
 
 package examples;
 
+import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.docgen.Source;
+import io.vertx.ext.auth.authentication.UsernamePasswordCredentials;
 import io.vertx.ext.mail.*;
 
 /**
@@ -48,6 +50,24 @@ public class MailExamples {
     config.setUsername("user");
     config.setPassword("password");
     MailClient mailClient = MailClient.create(vertx, config);
+  }
+
+  public void dynamicCredentials(Vertx vertx) {
+    MailConfig config = new MailConfig()
+      .setHostname("mail.example.com")
+      .setPort(587)
+      .setStarttls(StartTLSOptions.REQUIRED);
+    MailClient mailClient = MailClient.builder(vertx)
+      .with(config)
+      .withCredentialsSupplier(() -> {
+        Future<UsernamePasswordCredentials> future = retrieveCredentialsAsync();
+        return future;
+      })
+      .build();
+  }
+
+  private Future<UsernamePasswordCredentials> retrieveCredentialsAsync() {
+    return Future.succeededFuture();
   }
 
   public void mailMessage() {

--- a/src/main/java/io/vertx/ext/mail/MailClient.java
+++ b/src/main/java/io/vertx/ext/mail/MailClient.java
@@ -21,6 +21,7 @@ import io.vertx.core.*;
 import io.vertx.ext.mail.impl.MailClientImpl;
 
 import java.util.UUID;
+import java.util.function.Function;
 
 /**
  * SMTP mail client for Vert.x
@@ -59,6 +60,26 @@ public interface MailClient {
    */
   static MailClient createShared(Vertx vertx, MailConfig config, String poolName) {
     return new MailClientImpl(vertx, config, poolName);
+  }
+
+
+  /**
+   * Create a Mail client which shares its connection pool with any other Mail clients created with the same
+   * pool name. The access token provider function will be called for each connection to get the current 
+   * access token.
+   *
+   * @param vertx  the Vert.x instance
+   * @param config  the configuration
+   * @param poolName  the pool name
+   * @param accessTokenProvider  a function which provides the access token for the given MailConfig
+   * @return the client
+   */
+  static MailClient createSharedXOAuthClient(
+      Vertx vertx,
+      MailConfig config,
+      String poolName,
+      Function<MailConfig, String> accessTokenProvider) {
+    return new MailClientImpl(vertx, config, poolName, accessTokenProvider);
   }
 
   /**

--- a/src/main/java/io/vertx/ext/mail/MailClient.java
+++ b/src/main/java/io/vertx/ext/mail/MailClient.java
@@ -17,11 +17,11 @@
 package io.vertx.ext.mail;
 
 import io.vertx.codegen.annotations.VertxGen;
-import io.vertx.core.*;
-import io.vertx.ext.mail.impl.MailClientImpl;
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.ext.mail.impl.MailClientBuilderImpl;
 
-import java.util.UUID;
-import java.util.function.Function;
+import java.util.function.Supplier;
 
 /**
  * SMTP mail client for Vert.x
@@ -39,6 +39,15 @@ public interface MailClient {
   String DEFAULT_POOL_NAME = "DEFAULT_POOL";
 
   /**
+   * Provide a builder for {@link MailClient}.
+   * <p>
+   * It can be used to configure advanced settings like changing credentials with {@link MailClientBuilder#withCredentialsSupplier(Supplier)}.
+   */
+  static MailClientBuilder builder(Vertx vertx) {
+    return new MailClientBuilderImpl(vertx);
+  }
+
+  /**
    * Create a non shared instance of the mail client.
    *
    * @param vertx  the Vertx instance the operation will be run in
@@ -46,7 +55,7 @@ public interface MailClient {
    * @return MailClient instance that can then be used to send multiple mails
    */
   static MailClient create(Vertx vertx, MailConfig config) {
-    return new MailClientImpl(vertx, config, UUID.randomUUID().toString());
+    return builder(vertx).with(config).build();
   }
 
   /**
@@ -59,27 +68,7 @@ public interface MailClient {
    * @return the client
    */
   static MailClient createShared(Vertx vertx, MailConfig config, String poolName) {
-    return new MailClientImpl(vertx, config, poolName);
-  }
-
-
-  /**
-   * Create a Mail client which shares its connection pool with any other Mail clients created with the same
-   * pool name. The access token provider function will be called for each connection to get the current 
-   * access token.
-   *
-   * @param vertx  the Vert.x instance
-   * @param config  the configuration
-   * @param poolName  the pool name
-   * @param accessTokenProvider  a function which provides the access token for the given MailConfig
-   * @return the client
-   */
-  static MailClient createSharedXOAuthClient(
-      Vertx vertx,
-      MailConfig config,
-      String poolName,
-      Function<MailConfig, String> accessTokenProvider) {
-    return new MailClientImpl(vertx, config, poolName, accessTokenProvider);
+    return builder(vertx).with(config).shared(poolName).build();
   }
 
   /**
@@ -89,7 +78,7 @@ public interface MailClient {
    * @return the client
    */
   static MailClient createShared(Vertx vertx, MailConfig config) {
-    return new MailClientImpl(vertx, config, DEFAULT_POOL_NAME);
+    return builder(vertx).with(config).shared(DEFAULT_POOL_NAME).build();
   }
 
   /**

--- a/src/main/java/io/vertx/ext/mail/MailClientBuilder.java
+++ b/src/main/java/io/vertx/ext/mail/MailClientBuilder.java
@@ -1,0 +1,52 @@
+package io.vertx.ext.mail;
+
+import io.vertx.codegen.annotations.Fluent;
+import io.vertx.codegen.annotations.VertxGen;
+import io.vertx.core.Future;
+import io.vertx.ext.auth.authentication.UsernamePasswordCredentials;
+
+import java.util.function.Supplier;
+
+/**
+ * A builder for {@link MailClient}.
+ */
+@VertxGen
+public interface MailClientBuilder {
+
+  /**
+   * Set a configuration object.
+   *
+   * @param configuration to be used for sending mails
+   * @return a reference to this, so the API can be used fluently
+   */
+  @Fluent
+  MailClientBuilder with(MailConfig configuration);
+
+  /**
+   * Set a credentials supplier for the mail client.
+   * <p>
+   * By default, the credentials are fixed at creation time with {@link MailConfig#setUsername(String)} and {@link MailConfig#setPassword(String)}.
+   *
+   * @return a reference to this, so the API can be used fluently
+   */
+  @Fluent
+  MailClientBuilder withCredentialsSupplier(Supplier<Future<UsernamePasswordCredentials>> credentialsSupplier);
+
+  /**
+   * Set a shared client pool name.
+   * <p>
+   * The created client will share its connection pool with any other client created with the same pool name.
+   *
+   * @param poolName the shared pool name
+   * @return a reference to this, so the API can be used fluently
+   */
+  @Fluent
+  MailClientBuilder shared(String poolName);
+
+  /**
+   * Build and return the client.
+   *
+   * @return the client as configured by this builder
+   */
+  MailClient build();
+}

--- a/src/main/java/io/vertx/ext/mail/impl/MailClientBuilderImpl.java
+++ b/src/main/java/io/vertx/ext/mail/impl/MailClientBuilderImpl.java
@@ -1,0 +1,48 @@
+package io.vertx.ext.mail.impl;
+
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.ext.auth.authentication.UsernamePasswordCredentials;
+import io.vertx.ext.mail.MailClient;
+import io.vertx.ext.mail.MailClientBuilder;
+import io.vertx.ext.mail.MailConfig;
+
+import java.util.Objects;
+import java.util.UUID;
+import java.util.function.Supplier;
+
+public class MailClientBuilderImpl implements MailClientBuilder {
+
+  private final Vertx vertx;
+  private MailConfig configuration;
+  private Supplier<Future<UsernamePasswordCredentials>> credentialsSupplier;
+  private String poolName;
+
+  public MailClientBuilderImpl(Vertx vertx) {
+    this.vertx = vertx;
+  }
+
+  @Override
+  public MailClientBuilder with(MailConfig configuration) {
+    this.configuration = Objects.requireNonNull(configuration, "Configuration cannot be null");
+    return this;
+  }
+
+  @Override
+  public MailClientBuilder withCredentialsSupplier(Supplier<Future<UsernamePasswordCredentials>> credentialsSupplier) {
+    this.credentialsSupplier = credentialsSupplier;
+    return this;
+  }
+
+  @Override
+  public MailClientBuilder shared(String poolName) {
+    this.poolName = Objects.requireNonNull(poolName, "Shared pool name cannot be null");
+    return this;
+  }
+
+  @Override
+  public MailClient build() {
+    String poolName = this.poolName != null ? this.poolName : UUID.randomUUID().toString();
+    return new MailClientImpl(vertx, configuration, poolName, credentialsSupplier);
+  }
+}

--- a/src/main/java/io/vertx/ext/mail/impl/MailClientImpl.java
+++ b/src/main/java/io/vertx/ext/mail/impl/MailClientImpl.java
@@ -16,12 +16,16 @@
 
 package io.vertx.ext.mail.impl;
 
-import io.vertx.core.*;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
 import io.vertx.core.internal.ContextInternal;
 import io.vertx.core.internal.logging.Logger;
 import io.vertx.core.internal.logging.LoggerFactory;
 import io.vertx.core.shareddata.LocalMap;
 import io.vertx.core.shareddata.Shareable;
+import io.vertx.ext.auth.authentication.UsernamePasswordCredentials;
 import io.vertx.ext.mail.MailClient;
 import io.vertx.ext.mail.MailConfig;
 import io.vertx.ext.mail.MailMessage;
@@ -33,7 +37,7 @@ import io.vertx.ext.mail.mailencoder.MailEncoder;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.function.Function;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 /**
@@ -61,14 +65,15 @@ public class MailClientImpl implements MailClient {
   // the constructor may throw IllegalStateException because of wrong DKIM configuration.
   private final List<DKIMSigner> dkimSigners;
 
+  // Useful for testing
   public MailClientImpl(Vertx vertx, MailConfig config, String poolName) {
-    this(vertx, config, poolName, MailConfig::getPassword);
+    this(vertx, config, poolName, null);
   }
 
-  public MailClientImpl(Vertx vertx, MailConfig config, String poolName, Function<MailConfig, String> accessTokenProvider) {
+  public MailClientImpl(Vertx vertx, MailConfig config, String poolName, Supplier<Future<UsernamePasswordCredentials>> credentialsSupplier) {
     this.vertx = vertx;
     this.config = config;
-    this.holder = lookupHolder(poolName, config, accessTokenProvider);
+    this.holder = lookupHolder(poolName, config, credentialsSupplier);
     this.connectionPool = holder.pool();
     if (config != null && config.isEnableDKIM() && config.getDKIMSignOptions() != null) {
       dkimSigners = config.getDKIMSignOptions().stream().map(ops -> new DKIMSigner(ops, vertx)).collect(Collectors.toList());
@@ -176,12 +181,12 @@ public class MailClientImpl implements MailClient {
     return connectionPool;
   }
 
-  private MailHolder lookupHolder(String poolName, MailConfig config, Function<MailConfig, String> accessTokenProvider) {
+  private MailHolder lookupHolder(String poolName, MailConfig config, Supplier<Future<UsernamePasswordCredentials>> credentialsSupplier) {
     synchronized (vertx) {
       LocalMap<String, MailHolder> map = vertx.sharedData().getLocalMap(POOL_LOCAL_MAP_NAME);
       MailHolder theHolder = map.get(poolName);
       if (theHolder == null) {
-        theHolder = new MailHolder(vertx, config, () -> removeFromMap(map, poolName), accessTokenProvider);
+        theHolder = new MailHolder(vertx, config, () -> removeFromMap(map, poolName), credentialsSupplier);
         map.put(poolName, theHolder);
       } else {
         theHolder.incRefCount();
@@ -204,9 +209,9 @@ public class MailClientImpl implements MailClient {
     final Runnable closeRunner;
     int refCount = 1;
 
-    MailHolder(Vertx vertx, MailConfig config, Runnable closeRunner, Function<MailConfig, String> accessTokenProvider) {
+    MailHolder(Vertx vertx, MailConfig config, Runnable closeRunner, Supplier<Future<UsernamePasswordCredentials>> credentialsSupplier) {
       this.closeRunner = closeRunner;
-      this.pool = new SMTPConnectionPool(vertx, config, accessTokenProvider);
+      this.pool = new SMTPConnectionPool(vertx, config, credentialsSupplier);
     }
 
     SMTPConnectionPool pool() {

--- a/src/main/java/io/vertx/ext/mail/impl/SMTPAuthentication.java
+++ b/src/main/java/io/vertx/ext/mail/impl/SMTPAuthentication.java
@@ -22,6 +22,7 @@ import io.vertx.core.Promise;
 import io.vertx.core.internal.ContextInternal;
 import io.vertx.core.internal.logging.Logger;
 import io.vertx.core.internal.logging.LoggerFactory;
+import io.vertx.ext.auth.authentication.UsernamePasswordCredentials;
 import io.vertx.ext.mail.LoginOption;
 import io.vertx.ext.mail.MailConfig;
 import io.vertx.ext.mail.impl.sasl.AuthOperation;
@@ -46,18 +47,20 @@ class SMTPAuthentication {
   private final AuthOperationFactory authOperationFactory;
 
   private final Promise<Void> promise;
+  private final UsernamePasswordCredentials credentials;
 
-  SMTPAuthentication(ContextInternal context, SMTPConnection connection, MailConfig config, AuthOperationFactory authOperationFactory) {
+  SMTPAuthentication(ContextInternal context, SMTPConnection connection, MailConfig config, AuthOperationFactory authOperationFactory, UsernamePasswordCredentials credentials) {
     this.connection = connection;
     this.config = config;
     this.authOperationFactory = authOperationFactory;
     this.promise = context.promise();
+    this.credentials = credentials;
   }
 
   public Future<Void> start() {
     List<String> auths = intersectAllowedMethods();
     final boolean foundAllowedMethods = !auths.isEmpty();
-    if ( authOperationFactory.isLoginConfigured(config) && foundAllowedMethods) {
+    if (isLoginConfigured() && foundAllowedMethods) {
       authCmd(auths);
     } else {
       if (config.getLogin() == LoginOption.REQUIRED) {
@@ -114,7 +117,7 @@ class SMTPAuthentication {
   private void authMethod(String auth, Handler<Throwable> onError) {
     AuthOperation authMethod;
     try {
-      authMethod = authOperationFactory.createAuth(config, auth);
+      authMethod = authOperationFactory.createAuth(config, auth, credentials);
     } catch (IllegalArgumentException | SecurityException ex) {
       log.warn("authentication factory threw exception", ex);
       promise.fail(ex);
@@ -172,4 +175,9 @@ class SMTPAuthentication {
     });
   }
 
+  private boolean isLoginConfigured() {
+    return config.getLogin() != LoginOption.DISABLED
+      && ((config.getUsername() != null && config.getPassword() != null)
+      || credentials != null);
+  }
 }

--- a/src/main/java/io/vertx/ext/mail/impl/SMTPAuthentication.java
+++ b/src/main/java/io/vertx/ext/mail/impl/SMTPAuthentication.java
@@ -57,8 +57,7 @@ class SMTPAuthentication {
   public Future<Void> start() {
     List<String> auths = intersectAllowedMethods();
     final boolean foundAllowedMethods = !auths.isEmpty();
-    if (config.getLogin() != LoginOption.DISABLED && config.getUsername() != null && config.getPassword() != null
-      && foundAllowedMethods) {
+    if ( authOperationFactory.isLoginConfigured(config) && foundAllowedMethods) {
       authCmd(auths);
     } else {
       if (config.getLogin() == LoginOption.REQUIRED) {

--- a/src/test/java/io/vertx/tests/mail/client/MailAuthTest.java
+++ b/src/test/java/io/vertx/tests/mail/client/MailAuthTest.java
@@ -20,7 +20,6 @@ import io.vertx.ext.mail.LoginOption;
 import io.vertx.ext.mail.MailClient;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
-
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -55,6 +54,32 @@ public class MailAuthTest extends SMTPTestDummy {
       "221 2.0.0 Bye");
 
     testSuccess(mailClientLogin());
+  }
+
+  @Test
+  public void authLoginTestWithCredentialsSupplier(TestContext testContext) {
+    this.testContext = testContext;
+    smtpServer.setDialogue("220 example.com ESMTP",
+      "EHLO",
+      "250-example.com\n" +
+        "250 AUTH LOGIN",
+      "AUTH LOGIN",
+      "334 VXNlcm5hbWU6",
+      "eHh4",
+      "334 UGFzc3dvcmQ6",
+      "eXl5",
+      "250 2.1.0 Ok",
+      "MAIL FROM",
+      "250 2.1.0 Ok",
+      "RCPT TO",
+      "250 2.1.5 Ok",
+      "DATA",
+      "354 End data with <CR><LF>.<CR><LF>",
+      "250 2.0.0 Ok: queued as ABCD",
+      "QUIT",
+      "221 2.0.0 Bye");
+
+    testSuccess(mailClientLoginWithCredentialsSupplier());
   }
 
   @Test

--- a/src/test/java/io/vertx/tests/mail/client/SMTPTestBase.java
+++ b/src/test/java/io/vertx/tests/mail/client/SMTPTestBase.java
@@ -16,13 +16,14 @@
 
 package io.vertx.tests.mail.client;
 
+import io.vertx.core.Future;
 import io.vertx.core.internal.logging.Logger;
 import io.vertx.core.internal.logging.LoggerFactory;
+import io.vertx.ext.auth.authentication.UsernamePasswordCredentials;
 import io.vertx.ext.mail.*;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.Timeout;
 import io.vertx.test.core.VertxTestBase;
-
 import org.hamcrest.Matcher;
 import org.junit.After;
 import org.junit.Before;
@@ -30,6 +31,9 @@ import org.junit.Rule;
 import org.junit.rules.TestRule;
 import org.junit.rules.TestWatcher;
 import org.junit.runner.Description;
+
+import java.util.Objects;
+import java.util.function.Supplier;
 
 /**
  * Support functions for SMTP tests
@@ -68,6 +72,22 @@ public abstract class SMTPTestBase extends VertxTestBase {
    */
   protected MailClient mailClientLogin() {
     return MailClient.create(vertx, configLogin());
+  }
+
+  protected MailClient mailClientLoginWithCredentialsSupplier() {
+    MailConfig config = configLogin();
+    Supplier<Future<UsernamePasswordCredentials>> supplier = new Supplier<>() {
+
+      final String username = Objects.requireNonNull(config.getUsername());
+      final String password = Objects.requireNonNull(config.getPassword());
+
+      @Override
+      public Future<UsernamePasswordCredentials> get() {
+        return Future.succeededFuture(new UsernamePasswordCredentials(username, password));
+      }
+    };
+    config.setUsername(null).setPassword(null);
+    return MailClient.builder(vertx).with(config).withCredentialsSupplier(supplier).build();
   }
 
   /**

--- a/src/test/java/io/vertx/tests/mail/internal/sasl/AuthNTLMTest.java
+++ b/src/test/java/io/vertx/tests/mail/internal/sasl/AuthNTLMTest.java
@@ -22,9 +22,9 @@ import io.vertx.ext.mail.MailMessage;
 import io.vertx.ext.mail.impl.sasl.AuthOperation;
 import io.vertx.ext.mail.impl.sasl.AuthOperationFactory;
 import io.vertx.ext.mail.impl.sasl.NTLMAuth;
-import io.vertx.tests.mail.client.SMTPTestDummy;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.tests.mail.client.SMTPTestDummy;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -45,7 +45,7 @@ public class AuthNTLMTest extends SMTPTestDummy {
   @Test
   public void testAuthUserName() {
     MailConfig config = configLogin().setUsername("CORP\\testuserA").setPassword("test_password");
-    AuthOperation auth = new AuthOperationFactory(null).createAuth(config, "NTLM");
+    AuthOperation auth = new AuthOperationFactory(null).createAuth(config, "NTLM", null);
     assertNotNull(auth);
     assertTrue(auth instanceof NTLMAuth);
     NTLMAuth ntlmAuth = (NTLMAuth)auth;
@@ -54,7 +54,7 @@ public class AuthNTLMTest extends SMTPTestDummy {
     assertEquals("test_password", ntlmAuth.password());
 
     config = configLogin().setUsername("testuserA").setPassword("test_password").setNtDomain("CORP").setWorkstation("exVM");
-    auth = new AuthOperationFactory(null).createAuth(config, "NTLM");
+    auth = new AuthOperationFactory(null).createAuth(config, "NTLM", null);
     assertNotNull(auth);
     assertTrue(auth instanceof NTLMAuth);
     ntlmAuth = (NTLMAuth)auth;

--- a/src/test/java/io/vertx/tests/mail/internal/sasl/AuthOperationFactoryTest.java
+++ b/src/test/java/io/vertx/tests/mail/internal/sasl/AuthOperationFactoryTest.java
@@ -26,8 +26,8 @@ import io.vertx.ext.mail.impl.sasl.AuthXOAUTH2;
 import org.junit.Assert;
 import org.junit.Test;
 
-import static org.junit.Assert.*;
 import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
+import static org.junit.Assert.*;
 
 /**
  * @author <a href="http://oss.lehmann.cx/">Alexander Lehmann</a>
@@ -35,23 +35,21 @@ import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
 public class AuthOperationFactoryTest {
 
   /**
-   * Test method for
-   * {@link io.vertx.ext.mail.impl.sasl.AuthOperationFactory#createAuth(MailConfig, java.lang.String)}
-   * make sure that the default auth method works and is PLAIN
+   * Test that the default auth method works and is PLAIN
    */
   @Test
   public final void testCreateAuth() {
-    Assert.assertEquals(AuthPlain.class, new AuthOperationFactory(null).createAuth(new MailConfig().setUsername("user").setPassword("pw"), "PLAIN").getClass());
+    Assert.assertEquals(AuthPlain.class, new AuthOperationFactory(null).createAuth(new MailConfig().setUsername("user").setPassword("pw"), "PLAIN", null).getClass());
   }
 
   @Test(expected = IllegalArgumentException.class)
   public final void testAuthNotFound() {
-    assertNull(new AuthOperationFactory(null).createAuth(new MailConfig().setUsername("user").setPassword("pw"), "ASDF"));
+    assertNull(new AuthOperationFactory(null).createAuth(new MailConfig().setUsername("user").setPassword("pw"), "ASDF", null));
   }
 
   @Test
   public final void testCreateXOAUTH2Auth() {
-    assertEquals(AuthXOAUTH2.class, new AuthOperationFactory(null).createAuth(new MailConfig().setUsername("user").setPassword("token"), "XOAUTH2").getClass());
+    assertEquals(AuthXOAUTH2.class, new AuthOperationFactory(null).createAuth(new MailConfig().setUsername("user").setPassword("token"), "XOAUTH2", null).getClass());
   }
 
   @Test


### PR DESCRIPTION
In some production environments, credentials may be changed during the application lifetime (see https://github.com/quarkusio/quarkus/issues/39359)

This PR introduces a builder for the mail client.

With the builder, a user can set a supplier that provides fresh credentials asynchronously when required.