### PR TITLE
EmailAddress class doesn't handle parentheses in the display name properly per RFC5322

### DIFF
--- a/src/main/java/io/vertx/ext/mail/mailencoder/EmailAddress.java
+++ b/src/main/java/io/vertx/ext/mail/mailencoder/EmailAddress.java
@@ -23,7 +23,8 @@ import java.util.regex.Pattern;
  * represent a mail address with an email address part and an optional full name e.g. <br>
  * {@code user@example.com} <br>
  * {@code user@example.com (This User)} <br>
- * {@code Another User <other@example.net>}
+ * {@code Another User <other@example.net>} <br>
+ * {@code "display(name)" <sample@email.com>}
  * <p>
  * the constructor will validate the address catching format errors like excess spaces, newlines the test is not very
  * strict, for example an IDN address will be considered valid, even though SMTP doesn't work with that yet
@@ -48,16 +49,7 @@ public class EmailAddress {
    * @throws IllegalArgumentException if an address is not valid
    */
   public EmailAddress(String fullAddress) {
-
-    if (fullAddress.contains("(")) {
-      Matcher matcher = PATTERN_EMAIL.matcher(fullAddress);
-      if (matcher.matches()) {
-        email = matcher.group(1);
-        name = matcher.group(2);
-      } else {
-        throw new IllegalArgumentException("invalid email address [" + fullAddress + "]");
-      }
-    } else if (fullAddress.contains("<")) {
+    if (fullAddress.contains("<")) {
       Matcher matcher = PATTERN_EMAIL_ANGLE.matcher(fullAddress);
       if (matcher.matches()) {
         name = matcher.group(1);
@@ -66,6 +58,15 @@ public class EmailAddress {
         }
         email = matcher.group(2);
       } else {
+        throw new IllegalArgumentException("invalid email address [" + fullAddress + "]");
+      }
+    } else if (fullAddress.contains("(")) {
+      Matcher matcher = PATTERN_EMAIL.matcher(fullAddress);
+      if (matcher.matches()) {
+        email = matcher.group(1);
+        name = matcher.group(2);
+      }
+      else {
         throw new IllegalArgumentException("invalid email address [" + fullAddress + "]");
       }
     } else {

--- a/src/test/java/io/vertx/ext/mail/mailencoder/EmailAddressTest.java
+++ b/src/test/java/io/vertx/ext/mail/mailencoder/EmailAddressTest.java
@@ -37,6 +37,8 @@ public class EmailAddressTest {
     checkAddress("\"Last, First\" <user@example.com>", "[user@example.com,\"Last, First\"]");
     checkAddress("Last, First <user@example.com>", "[user@example.com,Last, First]");
     checkAddress("user@example.com (Last, First)", "[user@example.com,Last, First]");
+    // allow parentheses in display name (issue #218)
+    checkAddress("\"display(name)\" <sample@email.com>", "[sample@email.com,\"display(name)\"]");
     // <> can be used as MAIL FROM address
     checkAddress("", "[]");
     checkAddress("<>", "[]");
@@ -88,4 +90,9 @@ public class EmailAddressTest {
     new EmailAddress("<user@example.com");
   }
 
+  // from wikipedia: these special characters need to be in quotes
+  @Test(expected = IllegalArgumentException.class)
+  public void testEmailInvalid11() {
+    new EmailAddress("a\"b(c)d,e:f;g<h>i[j\\k]l@example.com");
+  }
 }


### PR DESCRIPTION
Motivation:

This addresses issue https://github.com/vert-x3/vertx-mail-client/issues/218 where emails with display names in parentheses are not sent.

This is a backport to 4.x from #223 

I have signed the eca with my username (dhufnagel).