### PR TITLE
Add spotless plugin and remove unused imports

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -209,6 +209,16 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>com.diffplug.spotless</groupId>
+        <artifactId>spotless-maven-plugin</artifactId>
+        <version>3.5.1</version>
+        <configuration>
+          <java>
+            <removeUnusedImports />
+          </java>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 

--- a/src/test/java/io/vertx/tests/mail/client/SMTPTestBase.java
+++ b/src/test/java/io/vertx/tests/mail/client/SMTPTestBase.java
@@ -35,8 +35,6 @@ import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 /**
  * Support functions for SMTP tests
  * <p>

--- a/src/test/java/io/vertx/tests/mail/internal/SMTPSendMailTest.java
+++ b/src/test/java/io/vertx/tests/mail/internal/SMTPSendMailTest.java
@@ -1,14 +1,11 @@
 package io.vertx.tests.mail.internal;
 
 import io.vertx.core.Expectation;
-import io.vertx.core.Future;
 import io.vertx.core.internal.logging.Logger;
 import io.vertx.core.internal.logging.LoggerFactory;
 import io.vertx.ext.mail.*;
-import io.vertx.ext.mail.impl.SMTPConnection;
 import io.vertx.ext.mail.impl.SMTPConnectionPool;
 import io.vertx.ext.mail.impl.SMTPResponse;
-import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import io.vertx.tests.mail.client.SMTPTestWiser;


### PR DESCRIPTION
Added spotless plugin to remove unused imports. I have just added the goal of removing unused imports, this can be further extended to impose a code style, import order etc.

cc @vietj I believe this will help with checks. You can use goal = `spotless:apply` to remove unused imports now.